### PR TITLE
feat/add export import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ build/
 one_updater.egg-info/
 .DS_Store
 dist/
+.vagrant/
+Vagrantfile

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
 -   repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
-    rev: v0.8.0
+    rev: v0.9.0
     hooks:
     -   id: pre-commit-update
 
 -   repo: https://github.com/sourcery-ai/sourcery
-    rev: v1.37.0
+    rev: v1.43.0
     hooks:
     -   id: sourcery
         # * review only changed lines:
@@ -13,26 +13,26 @@ repos:
         args: [--diff=git diff HEAD, --no-summary, one_updater/]
 
 -   repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 26.5.1
     hooks:
     -   id: black
         language_version: python3
 
 -   repo: https://github.com/pycqa/isort
-    rev: 6.0.1
+    rev: 8.0.1
     hooks:
     -   id: isort
         args: ["--profile", "black"]
 
 -   repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.7.19
+    rev: 0.11.16
     hooks:
     -   id: uv-lock
     -   id: uv-export
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
     -   id: check-yaml
         args: [--unsafe]
@@ -54,13 +54,13 @@ repos:
     -   id: ripsecrets
 
 -   repo: https://github.com/trufflesecurity/trufflehog
-    rev: v3.89.2
+    rev: v3.95.3
     hooks:
     -   id: trufflehog
         name: TruffleHog
         description: Detect secrets in your data.
-        entry: bash -c 'trufflehog git file://. --since-commit HEAD --only-verified
-          --fail'
+        entry: bash -c 'trufflehog git file://. --since-commit HEAD
+          --only-verified --fail'
         language: system
         stages: ["pre-commit"]
 

--- a/one_updater/cli.py
+++ b/one_updater/cli.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import json
 import logging
 import os
 import sys
@@ -8,6 +9,7 @@ from typing import Optional
 
 import yaml
 from rich.console import Console
+from rich.table import Table
 
 from one_updater.package_managers.base import PackageManager
 from one_updater.package_managers.registry import PackageManagerRegistry
@@ -213,6 +215,166 @@ def show_version():
         console.print("[red]Error: Could not determine version[/red]")
 
 
+def export_packages(
+    managers: Optional[list[str]],
+    output: Optional[str],
+    fmt: str,
+    verbose: bool,
+    skip: Optional[list[str]] = None,
+) -> None:
+    """Export installed packages grouped by package manager to YAML or JSON."""
+    supported = PackageManagerRegistry.EXPORT_SUPPORTED
+    targets = sorted([m for m in managers if m in supported] if managers else supported)
+    if skip:
+        targets = [m for m in targets if m not in skip]
+    for m in managers or []:
+        if m not in supported:
+            console.print(f"[yellow]! {m} is not export-supported, skipping[/yellow]")
+
+    result: dict[str, list[str]] = {}
+    for name in targets:
+        try:
+            pm = PackageManagerRegistry.get_manager(name, {"enabled": True})
+        except ValueError as e:
+            console.print(f"[yellow]! {e}, skipping[/yellow]")
+            continue
+
+        if not pm.is_available():
+            if verbose:
+                console.print(f"[yellow]! {name} not available, skipping[/yellow]")
+            continue
+
+        packages = pm.list_packages()
+        if packages is None:
+            console.print(f"[yellow]! {name} list not supported, skipping[/yellow]")
+            continue
+
+        if not packages:
+            console.print(f"[dim]- {name}: none found, skipping[/dim]")
+            continue
+        console.print(f"[green]\u2713 {name}[/green]: {len(packages)} package(s)")
+        result[name] = sorted(packages)
+
+    if not result:
+        console.print("[yellow]No packages found to export[/yellow]")
+        return
+
+    if fmt == "json":
+        text = json.dumps(result, indent=2)
+    else:
+        text = yaml.dump(result, default_flow_style=False, sort_keys=True)
+
+    if output:
+        with open(output, "w", encoding="utf-8") as f:
+            f.write(text)
+        console.print(f"\n[bold green]Exported to {output}[/bold green]")
+    else:
+        console.print("\n")
+        console.print(text)
+
+
+def import_packages(
+    file_path: str,
+    managers: Optional[list[str]],
+    dry_run: bool,
+    verbose: bool,
+    skip: Optional[list[str]] = None,
+) -> None:
+    """Read an export file and install all packages not already present."""
+    if not os.path.exists(file_path):
+        error_console.print(f"[red]Error: File not found: {file_path}[/red]")
+        sys.exit(1)
+
+    with open(file_path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    ext = os.path.splitext(file_path)[1].lower()
+    if ext == ".json":
+        try:
+            data = json.loads(content)
+        except json.JSONDecodeError as e:
+            error_console.print(f"[red]Error parsing JSON: {e}[/red]")
+            sys.exit(1)
+    else:
+        try:
+            data = yaml.safe_load(content)
+        except yaml.YAMLError as e:
+            error_console.print(f"[red]Error parsing YAML: {e}[/red]")
+            sys.exit(1)
+
+    if not isinstance(data, dict):
+        error_console.print(
+            "[red]Error: export file must map manager names to package lists[/red]"
+        )
+        sys.exit(1)
+
+    supported = PackageManagerRegistry.EXPORT_SUPPORTED
+    targets = sorted(m for m in data if m in supported)
+    if managers:
+        targets = [m for m in targets if m in managers]
+    if skip:
+        targets = [m for m in targets if m not in skip]
+
+    table = Table(title="Import Results", show_header=True)
+    table.add_column("Manager", style="cyan")
+    table.add_column("Package", style="white")
+    table.add_column("Status")
+
+    summary: dict[str, dict[str, int]] = {}
+
+    for name in targets:
+        packages = data[name]
+        if not isinstance(packages, list):
+            console.print(f"[yellow]! {name}: expected list, skipping[/yellow]")
+            continue
+
+        try:
+            pm = PackageManagerRegistry.get_manager(name, {"enabled": True})
+        except ValueError as e:
+            console.print(f"[yellow]! {e}, skipping[/yellow]")
+            continue
+
+        if not pm.is_available():
+            console.print(f"[yellow]! {name} not available, skipping[/yellow]")
+            continue
+
+        summary[name] = {"installed": 0, "skipped": 0, "failed": 0}
+
+        for pkg in packages:
+            if pm.is_package_installed(pkg):
+                summary[name]["skipped"] += 1
+                if verbose:
+                    table.add_row(
+                        name,
+                        pkg,
+                        "[yellow]skipped (already installed)[/yellow]",
+                    )
+                continue
+
+            if dry_run:
+                table.add_row(name, pkg, "[blue]would install[/blue]")
+                continue
+
+            if pm.install_package(pkg):
+                summary[name]["installed"] += 1
+                table.add_row(name, pkg, "[green]installed[/green]")
+            else:
+                summary[name]["failed"] += 1
+                table.add_row(name, pkg, "[red]failed[/red]")
+
+    console.print(table)
+
+    if summary:
+        console.print("\n[bold]Summary:[/bold]")
+        for name, counts in sorted(summary.items()):
+            console.print(
+                f"  {name}: "
+                f"[green]{counts['installed']} installed[/green], "
+                f"[yellow]{counts['skipped']} skipped[/yellow], "
+                f"[red]{counts['failed']} failed[/red]"
+            )
+
+
 def main():
     """Main entry point for the CLI."""
     description = """
@@ -226,6 +388,8 @@ Examples:
   %(prog)s list-managers           List all configured package managers
   %(prog)s update -m brew pip      Update only brew and pip
   %(prog)s upgrade                 Upgrade all enabled package managers
+  %(prog)s export -o pkgs.yaml     Export installed packages to a file
+  %(prog)s import pkgs.yaml        Install packages from an export file
   %(prog)s -h                      Show this help message
 """
 
@@ -338,6 +502,69 @@ https://github.com/timmyb824/one-updater
         parents=[common_parser],
     )
 
+    export_help = """
+    Export all installed packages grouped by package manager.
+    Writes YAML (default) or JSON to a file or stdout.
+    Use -m to limit to specific managers.
+    """
+    export_parser = subparsers.add_parser(
+        "export",
+        help="export installed packages to a file",
+        description=export_help,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[common_parser, manager_parser],
+    )
+    export_parser.add_argument(
+        "-o",
+        "--output",
+        metavar="FILE",
+        help="output file path (default: stdout)",
+    )
+    export_parser.add_argument(
+        "-f",
+        "--format",
+        choices=["yaml", "json"],
+        default="yaml",
+        help="output format (default: yaml)",
+    )
+    export_parser.add_argument(
+        "-s",
+        "--skip",
+        metavar="NAME",
+        action="append",
+        help="package manager(s) to skip (can be specified multiple times)",
+    )
+
+    import_help = """
+    Install packages from an export file.
+    Already-installed packages are skipped automatically.
+    Use -m to limit to specific managers from the file.
+    """
+    import_parser = subparsers.add_parser(
+        "import",
+        help="install packages from an export file",
+        description=import_help,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[common_parser, manager_parser],
+    )
+    import_parser.add_argument(
+        "file",
+        metavar="FILE",
+        help="path to the export file",
+    )
+    import_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="show what would be installed without doing it",
+    )
+    import_parser.add_argument(
+        "-s",
+        "--skip",
+        metavar="NAME",
+        action="append",
+        help="package manager(s) to skip (can be specified multiple times)",
+    )
+
     # Parse arguments
     args = parser.parse_args()
 
@@ -356,7 +583,7 @@ https://github.com/timmyb824/one-updater
         logger.debug(f"Command line arguments: {args}")
 
         # Load config file if needed
-        if args.command != "init":
+        if args.command not in ("init", "export", "import"):
             config_path = os.path.abspath(
                 os.path.expanduser(args.config or get_default_config_path())
             )
@@ -382,6 +609,22 @@ https://github.com/timmyb824/one-updater
             update_managers(config, args.manager, args.verbose)
         elif args.command == "upgrade":
             upgrade_managers(config, args.manager, args.verbose)
+        elif args.command == "export":
+            export_packages(
+                args.manager,
+                args.output,
+                args.format,
+                args.verbose,
+                args.skip,
+            )
+        elif args.command == "import":
+            import_packages(
+                args.file,
+                args.manager,
+                args.dry_run,
+                args.verbose,
+                args.skip,
+            )
         else:
             parser.print_help()
             sys.exit(1)

--- a/one_updater/cli.py
+++ b/one_updater/cli.py
@@ -14,6 +14,11 @@ from rich.table import Table
 from one_updater.package_managers.base import PackageManager
 from one_updater.package_managers.registry import PackageManagerRegistry
 
+
+class PackageImportError(Exception):
+    """Raised by import_packages for fatal input/parse errors."""
+
+
 console = Console()
 error_console = Console(stderr=True)
 logger = logging.getLogger(__name__)
@@ -283,7 +288,7 @@ def import_packages(
     """Read an export file and install all packages not already present."""
     if not os.path.exists(file_path):
         error_console.print(f"[red]Error: File not found: {file_path}[/red]")
-        sys.exit(1)
+        raise PackageImportError(f"File not found: {file_path}")
 
     with open(file_path, "r", encoding="utf-8") as f:
         content = f.read()
@@ -294,26 +299,36 @@ def import_packages(
             data = json.loads(content)
         except json.JSONDecodeError as e:
             error_console.print(f"[red]Error parsing JSON: {e}[/red]")
-            sys.exit(1)
+            raise PackageImportError(f"Invalid JSON: {e}") from e
     else:
         try:
             data = yaml.safe_load(content)
         except yaml.YAMLError as e:
             error_console.print(f"[red]Error parsing YAML: {e}[/red]")
-            sys.exit(1)
+            raise PackageImportError(f"Invalid YAML: {e}") from e
 
     if not isinstance(data, dict):
         error_console.print(
             "[red]Error: export file must map manager names to package lists[/red]"
         )
-        sys.exit(1)
+        raise PackageImportError("export file must map manager names to package lists")
 
     supported = PackageManagerRegistry.EXPORT_SUPPORTED
+    for m in sorted(data):
+        if m not in supported:
+            console.print(f"[yellow]! {m} not in EXPORT_SUPPORTED, ignoring[/yellow]")
     targets = sorted(m for m in data if m in supported)
     if managers:
         targets = [m for m in targets if m in managers]
     if skip:
         targets = [m for m in targets if m not in skip]
+
+    if not targets:
+        console.print(
+            "[yellow]No packages matched the selected managers/filters;"
+            " nothing to import.[/yellow]"
+        )
+        return
 
     table = Table(title="Import Results", show_header=True)
     table.add_column("Manager", style="cyan")
@@ -327,6 +342,19 @@ def import_packages(
         if not isinstance(packages, list):
             console.print(f"[yellow]! {name}: expected list, skipping[/yellow]")
             continue
+
+        invalid = [pkg for pkg in packages if not isinstance(pkg, str)]
+        if invalid:
+            error_console.print(
+                f"[red]Error: package list for '{name}' contains non-string "
+                f"entries: {[type(p).__name__ for p in invalid]}[/red]"
+            )
+            console.print(
+                "[yellow]Hint: ensure all package names are plain strings "
+                "in the export file.[/yellow]"
+            )
+            continue
+        packages = [pkg for pkg in packages if isinstance(pkg, str)]
 
         try:
             pm = PackageManagerRegistry.get_manager(name, {"enabled": True})
@@ -362,17 +390,22 @@ def import_packages(
                 summary[name]["failed"] += 1
                 table.add_row(name, pkg, "[red]failed[/red]")
 
-    console.print(table)
+    if not summary:
+        console.print(
+            "[yellow]Nothing was imported (all packages already installed"
+            " or no valid entries).[/yellow]"
+        )
+        return
 
-    if summary:
-        console.print("\n[bold]Summary:[/bold]")
-        for name, counts in sorted(summary.items()):
-            console.print(
-                f"  {name}: "
-                f"[green]{counts['installed']} installed[/green], "
-                f"[yellow]{counts['skipped']} skipped[/yellow], "
-                f"[red]{counts['failed']} failed[/red]"
-            )
+    console.print(table)
+    console.print("\n[bold]Summary:[/bold]")
+    for name, counts in sorted(summary.items()):
+        console.print(
+            f"  {name}: "
+            f"[green]{counts['installed']} installed[/green], "
+            f"[yellow]{counts['skipped']} skipped[/yellow], "
+            f"[red]{counts['failed']} failed[/red]"
+        )
 
 
 def main():
@@ -629,6 +662,8 @@ https://github.com/timmyb824/one-updater
             parser.print_help()
             sys.exit(1)
 
+    except PackageImportError:
+        sys.exit(1)
     except Exception as e:
         error_console.print(f"[red]Error: {e}[/red]")
         sys.exit(1)

--- a/one_updater/package_managers/apt.py
+++ b/one_updater/package_managers/apt.py
@@ -1,5 +1,7 @@
 """apt package manager implementation."""
 
+from typing import Optional
+
 from .base import PackageManager
 
 
@@ -23,3 +25,23 @@ class AptManager(PackageManager):
         return self.run_command(
             self.commands.get("upgrade", ["sudo", "apt", "upgrade", "-y"])
         )
+
+    def list_packages(self) -> Optional[list[str]]:
+        """Return all explicitly installed apt packages."""
+        if not self.is_available():
+            return None
+        ok, stdout, _ = self.run_command_with_output(["apt-mark", "showmanual"])
+        if not ok or not stdout:
+            return []
+        return [line.strip() for line in stdout.splitlines() if line.strip()]
+
+    def install_package(self, name: str) -> bool:
+        """Install an apt package by name."""
+        if not self.is_available():
+            return False
+        return self.run_command(["sudo", "apt-get", "install", "-y", name])
+
+    def is_package_installed(self, name: str) -> bool:
+        """Check whether an apt package is installed."""
+        ok, _, _ = self.run_command_with_output(["dpkg", "-s", name])
+        return ok

--- a/one_updater/package_managers/base.py
+++ b/one_updater/package_managers/base.py
@@ -76,6 +76,9 @@ class PackageManager(ABC):
                 self._status.start()
 
             return False
+        except FileNotFoundError:
+            logging.error(f"Command not found: {command[0]}")
+            return False
 
     def run_command_with_output(
         self, command: list[str]
@@ -91,6 +94,9 @@ class PackageManager(ABC):
             return True, result.stdout, result.stderr
         except subprocess.CalledProcessError as e:
             return False, e.stdout, e.stderr
+        except FileNotFoundError:
+            logging.error(f"Command not found: {command[0]}")
+            return False, "", ""
 
     def _check_available(self, operation: str) -> bool:
         """Check if package manager is available and log if not.
@@ -121,3 +127,18 @@ class PackageManager(ABC):
     def upgrade(self) -> bool:
         """Upgrade installed packages."""
         pass
+
+    def list_packages(self) -> Optional[list[str]]:
+        """Return a list of installed package names, or None if unsupported."""
+        return None
+
+    def install_package(self, _name: str) -> bool:
+        """Install a single package by name. Returns False if unsupported."""
+        return False
+
+    def is_package_installed(self, _name: str) -> bool:
+        """Check whether a package is already installed.
+
+        Returns False if unsupported.
+        """
+        return False

--- a/one_updater/package_managers/basher.py
+++ b/one_updater/package_managers/basher.py
@@ -1,12 +1,18 @@
 """basher package manager implementation."""
 
 import logging
+import os
 import subprocess
+from typing import Optional
 
 from .base import PackageManager
 
 
 class BasherManager(PackageManager):
+    """
+    Basher package manager implementation.
+    """
+
     def is_available(self) -> bool:
         return self.run_command(["which", "basher"])
 
@@ -39,3 +45,32 @@ class BasherManager(PackageManager):
             logging.error("Failed to get outdated basher packages")
             success = False
         return success
+
+    def list_packages(self) -> Optional[list[str]]:
+        """Return all basher-installed packages as user/package strings."""
+        if not self.is_available():
+            return None
+        cellar = os.path.expanduser("~/.basher/cellar/packages")
+        if not os.path.isdir(cellar):
+            return []
+        return [
+            f"{user}/{pkg}"
+            for user in os.listdir(cellar)
+            if os.path.isdir(user_dir := os.path.join(cellar, user))
+            for pkg in os.listdir(user_dir)
+            if os.path.isdir(os.path.join(user_dir, pkg))
+        ]
+
+    def install_package(self, name: str) -> bool:
+        """Install a basher package by user/package identifier."""
+        if not self.is_available():
+            return False
+        return self.run_command(["basher", "install", name])
+
+    def is_package_installed(self, name: str) -> bool:
+        """Check whether a basher package is installed."""
+        if "/" not in name:
+            return False
+        user, pkg = name.split("/", 1)
+        path = os.path.expanduser(f"~/.basher/cellar/packages/{user}/{pkg}")
+        return os.path.isdir(path)

--- a/one_updater/package_managers/brew.py
+++ b/one_updater/package_managers/brew.py
@@ -2,6 +2,7 @@
 
 import subprocess
 import sys
+from typing import Optional
 
 from .base import PackageManager
 
@@ -48,3 +49,24 @@ class HomebrewManager(PackageManager):
             self._status.start()
 
         return success
+
+    def list_packages(self) -> Optional[list[str]]:
+        """Return all installed Homebrew formulae and casks."""
+        if not self.is_available():
+            return None
+        ok, stdout, _ = self.run_command_with_output(["brew", "list", "--formula"])
+        formulae = stdout.splitlines() if ok and stdout else []
+        ok, stdout, _ = self.run_command_with_output(["brew", "list", "--cask"])
+        casks = stdout.splitlines() if ok and stdout else []
+        return formulae + casks
+
+    def install_package(self, name: str) -> bool:
+        """Install a Homebrew formula or cask by name."""
+        if not self.is_available():
+            return False
+        return self.run_command(["brew", "install", name])
+
+    def is_package_installed(self, name: str) -> bool:
+        """Check whether a Homebrew package is installed."""
+        ok, _, _ = self.run_command_with_output(["brew", "list", name])
+        return ok

--- a/one_updater/package_managers/cargo.py
+++ b/one_updater/package_managers/cargo.py
@@ -2,6 +2,7 @@
 
 import logging
 import subprocess
+from typing import Optional
 
 from .base import PackageManager
 
@@ -63,3 +64,23 @@ class CargoManager(PackageManager):
             success = False
 
         return success
+
+    def list_packages(self) -> Optional[list[str]]:
+        """Return all cargo-installed package names."""
+        if not self.is_available():
+            return None
+        ok, stdout, _ = self.run_command_with_output(["cargo", "install", "--list"])
+        if not ok or not stdout:
+            return []
+        return [line.split()[0] for line in stdout.splitlines() if ":" in line]
+
+    def install_package(self, name: str) -> bool:
+        """Install a cargo package by name."""
+        if not self.is_available():
+            return False
+        return self.run_command(["cargo", "install", name])
+
+    def is_package_installed(self, name: str) -> bool:
+        """Check whether a cargo package is installed."""
+        packages = self.list_packages()
+        return packages is not None and name in packages

--- a/one_updater/package_managers/dnf.py
+++ b/one_updater/package_managers/dnf.py
@@ -1,7 +1,7 @@
 """DNF package manager implementation."""
 
 import logging
-from typing import List, Optional
+from typing import Optional
 
 from .base import PackageManager
 
@@ -68,3 +68,25 @@ class DnfManager(PackageManager):
             return False
 
         return self.run_command(self.commands["upgrade"])
+
+    def list_packages(self) -> Optional[list[str]]:
+        """Return all explicitly installed DNF package names."""
+        if not self.is_available():
+            return None
+        ok, stdout, _ = self.run_command_with_output(
+            ["dnf", "repoquery", "--installed", "--qf", "%{name}"]
+        )
+        if not ok or not stdout:
+            return []
+        return [line.strip() for line in stdout.splitlines() if line.strip()]
+
+    def install_package(self, name: str) -> bool:
+        """Install a DNF package by name."""
+        if not self.is_available():
+            return False
+        return self.run_command(["sudo", "dnf", "install", "-y", name])
+
+    def is_package_installed(self, name: str) -> bool:
+        """Check whether a DNF package is installed."""
+        ok, _, _ = self.run_command_with_output(["dnf", "list", "installed", name])
+        return ok

--- a/one_updater/package_managers/flatpak.py
+++ b/one_updater/package_managers/flatpak.py
@@ -1,6 +1,7 @@
 """Flatpak package manager implementation."""
 
 import logging
+from typing import Optional
 
 from .base import PackageManager
 
@@ -70,3 +71,25 @@ class FlatpakManager(PackageManager):
             return False
 
         return self.run_command(self.commands["upgrade"])
+
+    def list_packages(self) -> Optional[list[str]]:
+        """Return all installed Flatpak application IDs."""
+        if not self.is_available():
+            return None
+        ok, stdout, _ = self.run_command_with_output(
+            ["flatpak", "list", "--app", "--columns=application"]
+        )
+        if not ok or not stdout:
+            return []
+        return [line.strip() for line in stdout.splitlines() if line.strip()]
+
+    def install_package(self, name: str) -> bool:
+        """Install a Flatpak application by ID."""
+        if not self.is_available():
+            return False
+        return self.run_command(["flatpak", "install", "-y", name])
+
+    def is_package_installed(self, name: str) -> bool:
+        """Check whether a Flatpak application is installed."""
+        packages = self.list_packages()
+        return packages is not None and name in packages

--- a/one_updater/package_managers/gem.py
+++ b/one_updater/package_managers/gem.py
@@ -1,6 +1,7 @@
 """gem package manager implementation."""
 
 import logging
+from typing import Optional
 
 from .base import PackageManager
 
@@ -30,3 +31,25 @@ class GemManager(PackageManager):
             return False
         # Update all installed gems
         return self.run_command(self.commands.get("upgrade", ["gem", "update"]))
+
+    def list_packages(self) -> Optional[list[str]]:
+        """Return all locally installed gem names."""
+        if not self.is_available():
+            return None
+        ok, stdout, _ = self.run_command_with_output(
+            ["gem", "list", "--local", "--no-versions"]
+        )
+        if not ok or not stdout:
+            return []
+        return [line.strip() for line in stdout.splitlines() if line.strip()]
+
+    def install_package(self, name: str) -> bool:
+        """Install a gem by name."""
+        if not self.is_available():
+            return False
+        return self.run_command(["gem", "install", name])
+
+    def is_package_installed(self, name: str) -> bool:
+        """Check whether a gem is installed."""
+        packages = self.list_packages()
+        return packages is not None and name in packages

--- a/one_updater/package_managers/ghcli.py
+++ b/one_updater/package_managers/ghcli.py
@@ -1,5 +1,7 @@
 """gh-cli package manager implementation."""
 
+from typing import Optional
+
 from .base import PackageManager
 
 
@@ -25,3 +27,28 @@ class GhCliManager(PackageManager):
         return self.run_command(
             self.commands.get("upgrade", ["gh", "extension", "upgrade", "--all"])
         )
+
+    def list_packages(self) -> Optional[list[str]]:
+        """Return all installed gh extension owner/repo identifiers."""
+        if not self.is_available():
+            return None
+        ok, stdout, _ = self.run_command_with_output(["gh", "extension", "list"])
+        if not ok or not stdout:
+            return []
+        packages = []
+        for line in stdout.splitlines():
+            parts = line.split()
+            if len(parts) >= 2:
+                packages.append(parts[1])  # owner/repo is second field
+        return packages
+
+    def install_package(self, name: str) -> bool:
+        """Install a gh extension by owner/repo identifier."""
+        if not self.is_available():
+            return False
+        return self.run_command(["gh", "extension", "install", name])
+
+    def is_package_installed(self, name: str) -> bool:
+        """Check whether a gh extension is installed."""
+        packages = self.list_packages()
+        return packages is not None and name in packages

--- a/one_updater/package_managers/go.py
+++ b/one_updater/package_managers/go.py
@@ -202,3 +202,81 @@ class GoManager(PackageManager):
             success = False
 
         return success
+
+    def list_packages(self) -> list[str] | None:
+        """Return Go module paths for all binaries installed in GOPATH/bin."""
+        if not self.is_available():
+            return None
+        try:
+            result = subprocess.run(
+                ["go", "env", "GOPATH"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            gopath = result.stdout.strip() or os.path.expanduser("~/go")
+        except subprocess.CalledProcessError:
+            return None
+
+        bin_dir = os.path.join(gopath, "bin")
+        if not os.path.isdir(bin_dir):
+            return []
+
+        binaries = [
+            b
+            for b in os.listdir(bin_dir)
+            if not b.startswith(".") and os.path.isfile(os.path.join(bin_dir, b))
+        ]
+
+        packages = []
+        for binary in binaries:
+            if binary in self.SPECIAL_CASES:
+                packages.append(self.SPECIAL_CASES[binary])
+                continue
+            try:
+                r = subprocess.run(
+                    ["go", "version", "-m", os.path.join(bin_dir, binary)],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                )
+                if module_path := next(
+                    (
+                        line.strip().split("\t")[1]
+                        for line in r.stdout.split("\n")
+                        if line.strip().startswith("mod\t")
+                    ),
+                    None,
+                ):
+                    packages.append(module_path)
+                else:
+                    packages.append(binary)
+            except subprocess.CalledProcessError:
+                packages.append(binary)
+        return packages
+
+    def install_package(self, name: str) -> bool:
+        """Install a Go package by module path using go install."""
+        if not self.is_available():
+            return False
+        return self.run_command(["go", "install", f"{name}@latest"])
+
+    def is_package_installed(self, name: str) -> bool:
+        """Check whether a Go package is installed (binary present in GOPATH/bin)."""
+        if not self.is_available():
+            return False
+        try:
+            result = subprocess.run(
+                ["go", "env", "GOPATH"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            gopath = result.stdout.strip() or os.path.expanduser("~/go")
+        except subprocess.CalledProcessError:
+            return False
+        bin_dir = os.path.join(gopath, "bin")
+        binary = os.path.basename(name.rstrip("/"))
+        if binary.startswith("cmd/"):
+            binary = binary[4:]
+        return os.path.isfile(os.path.join(bin_dir, binary))

--- a/one_updater/package_managers/go.py
+++ b/one_updater/package_managers/go.py
@@ -276,7 +276,9 @@ class GoManager(PackageManager):
         except subprocess.CalledProcessError:
             return False
         bin_dir = os.path.join(gopath, "bin")
-        binary = os.path.basename(name.rstrip("/"))
-        if binary.startswith("cmd/"):
-            binary = binary[4:]
+        stripped = name.rstrip("/")
+        # Handle paths like example.com/repo/cmd/tool — strip /cmd/<bin> pattern
+        if "/cmd/" in stripped:
+            stripped = stripped.split("/cmd/")[-1]
+        binary = os.path.basename(stripped)
         return os.path.isfile(os.path.join(bin_dir, binary))

--- a/one_updater/package_managers/krew.py
+++ b/one_updater/package_managers/krew.py
@@ -1,5 +1,7 @@
 """kubectl-krew package manager implementation."""
 
+from typing import Optional
+
 from .base import PackageManager
 
 
@@ -25,3 +27,23 @@ class KubectlKrewManager(PackageManager):
         return self.run_command(
             self.commands.get("upgrade", ["kubectl", "krew", "upgrade"])
         )
+
+    def list_packages(self) -> Optional[list[str]]:
+        """Return all installed krew plugin names."""
+        if not self.is_available():
+            return None
+        ok, stdout, _ = self.run_command_with_output(["kubectl", "krew", "list"])
+        if not ok or not stdout:
+            return []
+        return [line.strip() for line in stdout.splitlines() if line.strip()]
+
+    def install_package(self, name: str) -> bool:
+        """Install a krew plugin by name."""
+        if not self.is_available():
+            return False
+        return self.run_command(["kubectl", "krew", "install", name])
+
+    def is_package_installed(self, name: str) -> bool:
+        """Check whether a krew plugin is installed."""
+        packages = self.list_packages()
+        return packages is not None and name in packages

--- a/one_updater/package_managers/micro.py
+++ b/one_updater/package_managers/micro.py
@@ -1,5 +1,7 @@
 """micro-editor package manager implementation."""
 
+from typing import Optional
+
 from .base import PackageManager
 
 
@@ -26,3 +28,31 @@ class MicroEditorManager(PackageManager):
         return self.run_command(
             self.commands.get("upgrade", ["micro", "-plugin", "update"])
         )
+
+    def list_packages(self) -> Optional[list[str]]:
+        """Return all non-built-in installed micro plugins."""
+        if not self.is_available():
+            return None
+        ok, stdout, _ = self.run_command_with_output(["micro", "-plugin", "list"])
+        if not ok or not stdout:
+            return []
+        packages = []
+        for line in stdout.splitlines():
+            line = line.strip()
+            if not line or "(built-in)" in line:
+                continue
+            parts = line.split()
+            if parts and parts[0] not in ("The", "following", "plugins"):
+                packages.append(parts[0])
+        return packages
+
+    def install_package(self, name: str) -> bool:
+        """Install a micro plugin by name."""
+        if not self.is_available():
+            return False
+        return self.run_command(["micro", "-plugin", "install", name])
+
+    def is_package_installed(self, name: str) -> bool:
+        """Check whether a micro plugin is installed."""
+        packages = self.list_packages()
+        return packages is not None and name in packages

--- a/one_updater/package_managers/npm.py
+++ b/one_updater/package_managers/npm.py
@@ -1,5 +1,8 @@
 """npm package manager implementation."""
 
+import json
+from typing import Optional
+
 from .base import PackageManager
 
 
@@ -22,3 +25,30 @@ class NpmManager(PackageManager):
             return False
         # npm update -g handles both update and upgrade
         return self.run_command(self.commands.get("upgrade", ["npm", "update", "-g"]))
+
+    def list_packages(self) -> Optional[list[str]]:
+        """Return all globally installed npm package names."""
+        if not self.is_available():
+            return None
+        ok, stdout, _ = self.run_command_with_output(
+            ["npm", "list", "-g", "--depth=0", "--json"]
+        )
+        if not ok or not stdout:
+            return []
+        try:
+            data = json.loads(stdout)
+            deps = data.get("dependencies", {})
+            return [name for name in deps if name != "npm"]
+        except (json.JSONDecodeError, AttributeError):
+            return []
+
+    def install_package(self, name: str) -> bool:
+        """Install a global npm package by name."""
+        if not self.is_available():
+            return False
+        return self.run_command(["npm", "install", "-g", name])
+
+    def is_package_installed(self, name: str) -> bool:
+        """Check whether a global npm package is installed."""
+        packages = self.list_packages()
+        return packages is not None and name in packages

--- a/one_updater/package_managers/pacman.py
+++ b/one_updater/package_managers/pacman.py
@@ -1,7 +1,7 @@
 """Pacman package manager implementation."""
 
 import logging
-from typing import List, Optional
+from typing import Optional
 
 from .base import PackageManager
 
@@ -72,3 +72,23 @@ class PacmanManager(PackageManager):
             return False
 
         return self.run_command(self.commands["upgrade"])
+
+    def list_packages(self) -> Optional[list[str]]:
+        """Return all explicitly installed Pacman package names."""
+        if not self.is_available():
+            return None
+        ok, stdout, _ = self.run_command_with_output(["pacman", "-Qqe"])
+        if not ok or not stdout:
+            return []
+        return [line.strip() for line in stdout.splitlines() if line.strip()]
+
+    def install_package(self, name: str) -> bool:
+        """Install a Pacman package by name."""
+        if not self.is_available():
+            return False
+        return self.run_command(["sudo", "pacman", "-S", "--noconfirm", name])
+
+    def is_package_installed(self, name: str) -> bool:
+        """Check whether a Pacman package is installed."""
+        ok, _, _ = self.run_command_with_output(["pacman", "-Q", name])
+        return ok

--- a/one_updater/package_managers/pip.py
+++ b/one_updater/package_managers/pip.py
@@ -5,6 +5,7 @@ import logging
 import os
 import subprocess
 from pathlib import Path
+from typing import Optional
 
 from .base import PackageManager
 
@@ -267,3 +268,23 @@ class PipManager(PackageManager):
             if self.verbose and e.stderr:
                 logging.error(f"Error output: {e.stderr}")
             return False
+
+    def list_packages(self) -> Optional[list[str]]:
+        """Return all pip-installed packages using the system pip."""
+        ok, stdout, _ = self.run_command_with_output(["pip", "list", "--format=json"])
+        if not ok or not stdout:
+            return None
+        try:
+            packages = json.loads(stdout)
+            return [pkg["name"] for pkg in packages]
+        except (json.JSONDecodeError, KeyError):
+            return None
+
+    def install_package(self, name: str) -> bool:
+        """Install a pip package by name."""
+        return self.run_command(["pip", "install", name])
+
+    def is_package_installed(self, name: str) -> bool:
+        """Check whether a pip package is installed."""
+        ok, _, _ = self.run_command_with_output(["pip", "show", name])
+        return ok

--- a/one_updater/package_managers/pip.py
+++ b/one_updater/package_managers/pip.py
@@ -273,12 +273,12 @@ class PipManager(PackageManager):
         """Return all pip-installed packages using the system pip."""
         ok, stdout, _ = self.run_command_with_output(["pip", "list", "--format=json"])
         if not ok or not stdout:
-            return None
+            return []
         try:
             packages = json.loads(stdout)
             return [pkg["name"] for pkg in packages]
         except (json.JSONDecodeError, KeyError):
-            return None
+            return []
 
     def install_package(self, name: str) -> bool:
         """Install a pip package by name."""

--- a/one_updater/package_managers/pipx.py
+++ b/one_updater/package_managers/pipx.py
@@ -1,5 +1,7 @@
 """pipx package manager implementation."""
 
+from typing import Optional
+
 from .base import PackageManager
 
 
@@ -21,3 +23,23 @@ class PipxManager(PackageManager):
         if not self.is_available():
             return False
         return self.run_command(self.commands.get("upgrade", ["pipx", "upgrade-all"]))
+
+    def list_packages(self) -> Optional[list[str]]:
+        """Return all pipx-installed package names."""
+        if not self.is_available():
+            return None
+        ok, stdout, _ = self.run_command_with_output(["pipx", "list", "--short"])
+        if not ok or not stdout:
+            return []
+        return [parts[0] for line in stdout.splitlines() if (parts := line.split())]
+
+    def install_package(self, name: str) -> bool:
+        """Install a pipx package by name."""
+        if not self.is_available():
+            return False
+        return self.run_command(["pipx", "install", name])
+
+    def is_package_installed(self, name: str) -> bool:
+        """Check whether a pipx package is installed."""
+        packages = self.list_packages()
+        return packages is not None and name in packages

--- a/one_updater/package_managers/registry.py
+++ b/one_updater/package_managers/registry.py
@@ -49,6 +49,29 @@ class PackageManagerRegistry:
         "uv": UvManager,
     }
 
+    EXPORT_SUPPORTED: frozenset[str] = frozenset(
+        {
+            "apt",
+            "basher",
+            "brew",
+            "cargo",
+            "dnf",
+            "flatpak",
+            "gem",
+            "gh-cli",
+            "go",
+            "krew",
+            "micro",
+            "npm",
+            "pacman",
+            "pip",
+            "pipx",
+            "snap",
+            "uv",
+            "vagrant",
+        }
+    )
+
     @classmethod
     def get_manager(cls, name: str, config: dict) -> PackageManager:
         """Get a package manager instance by name."""

--- a/one_updater/package_managers/snap.py
+++ b/one_updater/package_managers/snap.py
@@ -1,5 +1,7 @@
 """snap package manager implementation."""
 
+from typing import Optional
+
 from .base import PackageManager
 
 
@@ -27,3 +29,29 @@ class SnapManager(PackageManager):
         return self.run_command(
             self.commands.get("upgrade", ["sudo", "snap", "refresh"])
         )
+
+    def list_packages(self) -> Optional[list[str]]:
+        """Return all installed snap package names (excluding snapd)."""
+        if not self.is_available():
+            return None
+        ok, stdout, _ = self.run_command_with_output(["snap", "list", "--color=never"])
+        if not ok or not stdout:
+            return []
+        lines = stdout.splitlines()
+        packages = []
+        for line in lines[1:]:  # skip header row
+            parts = line.split()
+            if parts and parts[0] != "snapd":
+                packages.append(parts[0])
+        return packages
+
+    def install_package(self, name: str) -> bool:
+        """Install a snap package by name."""
+        if not self.is_available():
+            return False
+        return self.run_command(["sudo", "snap", "install", name])
+
+    def is_package_installed(self, name: str) -> bool:
+        """Check whether a snap package is installed."""
+        ok, _, _ = self.run_command_with_output(["snap", "list", name])
+        return ok

--- a/one_updater/package_managers/uv.py
+++ b/one_updater/package_managers/uv.py
@@ -1,5 +1,7 @@
 """uv package manager implementation."""
 
+from typing import Optional
+
 from .base import PackageManager
 
 
@@ -24,3 +26,27 @@ class UvManager(PackageManager):
         return self.run_command(
             self.commands.get("upgrade", ["uv", "tool", "upgrade", "--all"])
         )
+
+    def list_packages(self) -> Optional[list[str]]:
+        """Return all uv tool package names."""
+        if not self.is_available():
+            return None
+        ok, stdout, _ = self.run_command_with_output(["uv", "tool", "list"])
+        if not ok or not stdout:
+            return []
+        return [
+            line.split()[0]
+            for line in stdout.splitlines()
+            if line and not line.startswith(" ") and not line.startswith("-")
+        ]
+
+    def install_package(self, name: str) -> bool:
+        """Install a uv tool package by name."""
+        if not self.is_available():
+            return False
+        return self.run_command(["uv", "tool", "install", name])
+
+    def is_package_installed(self, name: str) -> bool:
+        """Check whether a uv tool package is installed."""
+        packages = self.list_packages()
+        return packages is not None and name in packages

--- a/one_updater/package_managers/vagrant.py
+++ b/one_updater/package_managers/vagrant.py
@@ -1,5 +1,7 @@
 """vagrant package manager implementation."""
 
+from typing import Optional
+
 from .base import PackageManager
 
 
@@ -16,6 +18,34 @@ class VagrantPluginManager(PackageManager):
         return self.run_command(["vagrant", "plugin", "update"])
 
     def upgrade(self) -> bool:
+        """Upgrade vagrant plugins."""
         if not self.is_available():
             return False
         return self.run_command(["vagrant", "plugin", "update"])
+
+    def list_packages(self) -> Optional[list[str]]:
+        """Return all installed vagrant plugin names."""
+        if not self.is_available():
+            return None
+        ok, stdout, _ = self.run_command_with_output(["vagrant", "plugin", "list"])
+        if not ok or not stdout:
+            return []
+        return [
+            parts[0]
+            for line in stdout.splitlines()
+            if line
+            and not line[0].isspace()
+            and (parts := line.split())
+            and not parts[0].startswith("-")
+        ]
+
+    def install_package(self, name: str) -> bool:
+        """Install a vagrant plugin by name."""
+        if not self.is_available():
+            return False
+        return self.run_command(["vagrant", "plugin", "install", name])
+
+    def is_package_installed(self, name: str) -> bool:
+        """Check whether a vagrant plugin is installed."""
+        packages = self.list_packages()
+        return packages is not None and name in packages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ dev = [
   "isort",
   "pyinstaller",
   "pyyaml",
+  "ansible",
+  "passlib",
 ]
 
 [tool.uv]

--- a/tests/test_export_import.py
+++ b/tests/test_export_import.py
@@ -1,0 +1,353 @@
+"""Tests for export/import CLI functionality."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from one_updater.cli import export_packages, import_packages
+from one_updater.package_managers.brew import HomebrewManager
+from one_updater.package_managers.cargo import CargoManager
+from one_updater.package_managers.pipx import PipxManager
+from one_updater.package_managers.registry import PackageManagerRegistry
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pm(available: bool, packages: list[str] | None) -> MagicMock:
+    """Return a mock PackageManager with configured behaviour."""
+    pm = MagicMock()
+    pm.is_available.return_value = available
+    pm.list_packages.return_value = packages
+    pm.is_package_installed.side_effect = lambda name: name in (packages or [])
+    pm.install_package.return_value = True
+    return pm
+
+
+# ---------------------------------------------------------------------------
+# list_packages / install_package / is_package_installed — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestHomebrewMethods:
+    """Unit tests for HomebrewManager export/import methods."""
+
+    def test_list_packages_unavailable(self) -> None:
+        """list_packages returns None when brew is not available."""
+        mgr = HomebrewManager({})
+        with patch.object(mgr, "is_available", return_value=False):
+            assert mgr.list_packages() is None
+
+    def test_list_packages_combines_formulae_and_casks(self) -> None:
+        """list_packages concatenates formulae and cask results."""
+        mgr = HomebrewManager({})
+        with (
+            patch.object(mgr, "is_available", return_value=True),
+            patch.object(
+                mgr,
+                "run_command_with_output",
+                side_effect=[
+                    (True, "git\nvim\n", ""),
+                    (True, "iterm2\n", ""),
+                ],
+            ),
+        ):
+            result = mgr.list_packages()
+        assert result == ["git", "vim", "iterm2"]
+
+    def test_install_package_calls_brew_install(self) -> None:
+        """install_package delegates to brew install <name>."""
+        mgr = HomebrewManager({})
+        with (
+            patch.object(mgr, "is_available", return_value=True),
+            patch.object(mgr, "run_command", return_value=True) as mock_run,
+        ):
+            assert mgr.install_package("ripgrep") is True
+            mock_run.assert_called_once_with(["brew", "install", "ripgrep"])
+
+    def test_is_package_installed_true(self) -> None:
+        """is_package_installed returns True when brew list succeeds."""
+        mgr = HomebrewManager({})
+        with patch.object(
+            mgr, "run_command_with_output", return_value=(True, "git\n", "")
+        ):
+            assert mgr.is_package_installed("git") is True
+
+    def test_is_package_installed_false(self) -> None:
+        """is_package_installed returns False when brew list fails."""
+        mgr = HomebrewManager({})
+        with patch.object(mgr, "run_command_with_output", return_value=(False, "", "")):
+            assert mgr.is_package_installed("no-such-pkg") is False
+
+
+class TestPipxMethods:
+    """Unit tests for PipxManager export/import methods."""
+
+    def test_list_packages_parses_short_output(self) -> None:
+        """list_packages extracts the first token from each line."""
+        mgr = PipxManager({})
+        with (
+            patch.object(mgr, "is_available", return_value=True),
+            patch.object(
+                mgr,
+                "run_command_with_output",
+                return_value=(True, "black 23.3.0\ncowsay 6.0\n", ""),
+            ),
+        ):
+            result = mgr.list_packages()
+        assert result == ["black", "cowsay"]
+
+    def test_is_package_installed_delegates_to_list(self) -> None:
+        """is_package_installed checks membership in list_packages result."""
+        mgr = PipxManager({})
+        with patch.object(mgr, "list_packages", return_value=["black", "cowsay"]):
+            assert mgr.is_package_installed("black") is True
+            assert mgr.is_package_installed("ruff") is False
+
+    def test_is_package_installed_none_returns_false(self) -> None:
+        """is_package_installed returns False when list_packages is None."""
+        mgr = PipxManager({})
+        with patch.object(mgr, "list_packages", return_value=None):
+            assert mgr.is_package_installed("black") is False
+
+
+class TestCargoMethods:
+    """Unit tests for CargoManager export/import methods."""
+
+    def test_list_packages_parses_install_list(self) -> None:
+        """list_packages extracts crate names from cargo install --list."""
+        mgr = CargoManager({})
+        output = "bat v0.23.0:\n" "    bat\n" "ripgrep v13.0.0:\n" "    rg\n"
+        with (
+            patch.object(mgr, "is_available", return_value=True),
+            patch.object(
+                mgr,
+                "run_command_with_output",
+                return_value=(True, output, ""),
+            ),
+        ):
+            result = mgr.list_packages()
+        assert result == ["bat", "ripgrep"]
+
+    def test_install_package_calls_cargo_install(self) -> None:
+        """install_package delegates to cargo install <name>."""
+        mgr = CargoManager({})
+        with (
+            patch.object(mgr, "is_available", return_value=True),
+            patch.object(mgr, "run_command", return_value=True) as mock_run,
+        ):
+            assert mgr.install_package("bat") is True
+            mock_run.assert_called_once_with(["cargo", "install", "bat"])
+
+
+# ---------------------------------------------------------------------------
+# export_packages CLI function
+# ---------------------------------------------------------------------------
+
+
+class TestExportPackages:
+    """Integration-style tests for the export_packages CLI function."""
+
+    def test_export_to_stdout_yaml(self, capsys) -> None:
+        """export_packages prints YAML to stdout when no output file given."""
+        mock_pm = _make_pm(available=True, packages=["git", "vim"])
+
+        with patch.object(PackageManagerRegistry, "get_manager", return_value=mock_pm):
+            export_packages(managers=["brew"], output=None, fmt="yaml", verbose=False)
+
+        captured = capsys.readouterr()
+        assert "git" in captured.out
+        assert "vim" in captured.out
+
+    def test_export_to_file_json(self, tmp_path) -> None:
+        """export_packages writes valid JSON when fmt='json' and output given."""
+        mock_pm = _make_pm(available=True, packages=["ripgrep"])
+        out_file = str(tmp_path / "packages.json")
+
+        with patch.object(PackageManagerRegistry, "get_manager", return_value=mock_pm):
+            export_packages(
+                managers=["cargo"],
+                output=out_file,
+                fmt="json",
+                verbose=False,
+            )
+
+        with open(out_file, encoding="utf-8") as f:
+            data = json.load(f)
+        assert data == {"cargo": ["ripgrep"]}
+
+    def test_export_skips_unavailable_manager(self, capsys) -> None:
+        """export_packages skips unavailable managers silently (verbose=False)."""
+        mock_pm = _make_pm(available=False, packages=None)
+
+        with patch.object(PackageManagerRegistry, "get_manager", return_value=mock_pm):
+            export_packages(managers=["brew"], output=None, fmt="yaml", verbose=False)
+
+        captured = capsys.readouterr()
+        assert "No packages found" in captured.out
+
+    def test_export_skips_unsupported_manager_with_warning(self, capsys) -> None:
+        """export_packages warns and skips managers not in EXPORT_SUPPORTED."""
+        export_packages(managers=["tldr"], output=None, fmt="yaml", verbose=False)
+        captured = capsys.readouterr()
+        assert "not export-supported" in captured.out
+
+    def test_export_to_file_yaml(self, tmp_path) -> None:
+        """export_packages writes valid YAML when fmt='yaml' and output given."""
+        mock_pm = _make_pm(available=True, packages=["black", "ruff"])
+        out_file = str(tmp_path / "packages.yaml")
+
+        with patch.object(PackageManagerRegistry, "get_manager", return_value=mock_pm):
+            export_packages(
+                managers=["pipx"],
+                output=out_file,
+                fmt="yaml",
+                verbose=False,
+            )
+
+        with open(out_file, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        assert data == {"pipx": ["black", "ruff"]}
+
+
+# ---------------------------------------------------------------------------
+# import_packages CLI function
+# ---------------------------------------------------------------------------
+
+
+class TestImportPackages:
+    """Integration-style tests for the import_packages CLI function."""
+
+    def _write_export(self, tmp_path, data: dict, fmt: str = "yaml") -> str:
+        """Write a mock export file and return its path."""
+        if fmt == "json":
+            path = tmp_path / "packages.json"
+            path.write_text(json.dumps(data))
+        else:
+            path = tmp_path / "packages.yaml"
+            path.write_text(yaml.dump(data))
+        return str(path)
+
+    def test_import_skips_already_installed(self, tmp_path) -> None:
+        """import_packages skips packages that are already installed."""
+        data = {"brew": ["git", "vim"]}
+        file_path = self._write_export(tmp_path, data)
+
+        mock_pm = _make_pm(available=True, packages=["git", "vim"])
+
+        with patch.object(PackageManagerRegistry, "get_manager", return_value=mock_pm):
+            import_packages(
+                file_path=file_path,
+                managers=None,
+                dry_run=False,
+                verbose=False,
+            )
+
+        mock_pm.install_package.assert_not_called()
+
+    def test_import_installs_missing_packages(self, tmp_path) -> None:
+        """import_packages calls install_package for packages not installed."""
+        data = {"brew": ["git", "ripgrep"]}
+        file_path = self._write_export(tmp_path, data)
+
+        mock_pm = _make_pm(available=True, packages=["git"])
+
+        with patch.object(PackageManagerRegistry, "get_manager", return_value=mock_pm):
+            import_packages(
+                file_path=file_path,
+                managers=None,
+                dry_run=False,
+                verbose=False,
+            )
+
+        mock_pm.install_package.assert_called_once_with("ripgrep")
+
+    def test_import_dry_run_does_not_install(self, tmp_path) -> None:
+        """import_packages does not call install_package in dry-run mode."""
+        data = {"cargo": ["bat", "fd"]}
+        file_path = self._write_export(tmp_path, data)
+
+        mock_pm = _make_pm(available=True, packages=[])
+
+        with patch.object(PackageManagerRegistry, "get_manager", return_value=mock_pm):
+            import_packages(
+                file_path=file_path,
+                managers=None,
+                dry_run=True,
+                verbose=False,
+            )
+
+        mock_pm.install_package.assert_not_called()
+
+    def test_import_reads_json_file(self, tmp_path) -> None:
+        """import_packages auto-detects JSON format from .json extension."""
+        data = {"pipx": ["black"]}
+        file_path = self._write_export(tmp_path, data, fmt="json")
+
+        mock_pm = _make_pm(available=True, packages=[])
+
+        with patch.object(PackageManagerRegistry, "get_manager", return_value=mock_pm):
+            import_packages(
+                file_path=file_path,
+                managers=None,
+                dry_run=False,
+                verbose=False,
+            )
+
+        mock_pm.install_package.assert_called_once_with("black")
+
+    def test_import_file_not_found_exits(self, tmp_path) -> None:
+        """import_packages calls sys.exit when the file does not exist."""
+        with pytest.raises(SystemExit):
+            import_packages(
+                file_path=str(tmp_path / "nonexistent.yaml"),
+                managers=None,
+                dry_run=False,
+                verbose=False,
+            )
+
+    def test_import_manager_filter(self, tmp_path) -> None:
+        """import_packages only processes managers listed in managers arg."""
+        data = {"brew": ["git"], "cargo": ["bat"]}
+        file_path = self._write_export(tmp_path, data)
+
+        brew_pm = _make_pm(available=True, packages=[])
+        cargo_pm = _make_pm(available=True, packages=[])
+
+        def _get_manager(name: str, _cfg: dict):
+            """Return the appropriate mock PM by name."""
+            return brew_pm if name == "brew" else cargo_pm
+
+        with patch.object(
+            PackageManagerRegistry, "get_manager", side_effect=_get_manager
+        ):
+            import_packages(
+                file_path=file_path,
+                managers=["brew"],
+                dry_run=False,
+                verbose=False,
+            )
+
+        brew_pm.install_package.assert_called_once_with("git")
+        cargo_pm.install_package.assert_not_called()
+
+    def test_import_skips_unavailable_manager(self, tmp_path) -> None:
+        """import_packages skips managers that are not available."""
+        data = {"brew": ["git"]}
+        file_path = self._write_export(tmp_path, data)
+
+        mock_pm = _make_pm(available=False, packages=None)
+
+        with patch.object(PackageManagerRegistry, "get_manager", return_value=mock_pm):
+            import_packages(
+                file_path=file_path,
+                managers=None,
+                dry_run=False,
+                verbose=False,
+            )
+
+        mock_pm.install_package.assert_not_called()

--- a/tests/test_export_import.py
+++ b/tests/test_export_import.py
@@ -6,25 +6,31 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 
-from one_updater.cli import export_packages, import_packages
+from one_updater.cli import PackageImportError, export_packages, import_packages
 from one_updater.package_managers.brew import HomebrewManager
 from one_updater.package_managers.cargo import CargoManager
 from one_updater.package_managers.pipx import PipxManager
 from one_updater.package_managers.registry import PackageManagerRegistry
-
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 
-def _make_pm(available: bool, packages: list[str] | None) -> MagicMock:
+def _make_pm(
+    available: bool,
+    packages: list[str] | None,
+    failed_packages: set[str] | None = None,
+) -> MagicMock:
     """Return a mock PackageManager with configured behaviour."""
     pm = MagicMock()
     pm.is_available.return_value = available
     pm.list_packages.return_value = packages
     pm.is_package_installed.side_effect = lambda name: name in (packages or [])
-    pm.install_package.return_value = True
+    if failed_packages:
+        pm.install_package.side_effect = lambda name: name not in failed_packages
+    else:
+        pm.install_package.return_value = True
     return pm
 
 
@@ -113,6 +119,65 @@ class TestPipxMethods:
         mgr = PipxManager({})
         with patch.object(mgr, "list_packages", return_value=None):
             assert mgr.is_package_installed("black") is False
+
+
+class TestHomebrewNegativePaths:
+    """Negative-path tests for HomebrewManager."""
+
+    def test_install_package_unavailable_returns_false(self) -> None:
+        """install_package returns False and skips run_command when unavailable."""
+        mgr = HomebrewManager({})
+        with (
+            patch.object(mgr, "is_available", return_value=False),
+            patch.object(mgr, "run_command") as mock_run,
+        ):
+            result = mgr.install_package("ripgrep")
+        assert result is False
+        mock_run.assert_not_called()
+
+
+class TestPipxNegativePaths:
+    """Negative-path tests for PipxManager."""
+
+    def test_list_packages_command_failure_returns_empty(self) -> None:
+        """list_packages returns [] when run_command_with_output fails."""
+        mgr = PipxManager({})
+        with (
+            patch.object(mgr, "is_available", return_value=True),
+            patch.object(mgr, "run_command_with_output", return_value=(False, "", "")),
+        ):
+            assert mgr.list_packages() == []
+
+    def test_list_packages_empty_stdout_returns_empty(self) -> None:
+        """list_packages returns [] when stdout is empty."""
+        mgr = PipxManager({})
+        with (
+            patch.object(mgr, "is_available", return_value=True),
+            patch.object(mgr, "run_command_with_output", return_value=(True, "", "")),
+        ):
+            assert mgr.list_packages() == []
+
+
+class TestCargoNegativePaths:
+    """Negative-path tests for CargoManager."""
+
+    def test_list_packages_command_failure_returns_empty(self) -> None:
+        """list_packages returns [] when run_command_with_output fails."""
+        mgr = CargoManager({})
+        with (
+            patch.object(mgr, "is_available", return_value=True),
+            patch.object(mgr, "run_command_with_output", return_value=(False, "", "")),
+        ):
+            assert mgr.list_packages() == []
+
+    def test_list_packages_empty_stdout_returns_empty(self) -> None:
+        """list_packages returns [] when stdout is empty."""
+        mgr = CargoManager({})
+        with (
+            patch.object(mgr, "is_available", return_value=True),
+            patch.object(mgr, "run_command_with_output", return_value=(True, "", "")),
+        ):
+            assert mgr.list_packages() == []
 
 
 class TestCargoMethods:
@@ -300,15 +365,110 @@ class TestImportPackages:
 
         mock_pm.install_package.assert_called_once_with("black")
 
-    def test_import_file_not_found_exits(self, tmp_path) -> None:
-        """import_packages calls sys.exit when the file does not exist."""
-        with pytest.raises(SystemExit):
+    def test_import_file_not_found_raises(self, tmp_path) -> None:
+        """import_packages raises PackageImportError when the file does not exist."""
+        with pytest.raises(PackageImportError):
             import_packages(
                 file_path=str(tmp_path / "nonexistent.yaml"),
                 managers=None,
                 dry_run=False,
                 verbose=False,
             )
+
+    def test_import_invalid_json_raises(self, tmp_path) -> None:
+        """import_packages raises PackageImportError on malformed JSON."""
+        path = tmp_path / "packages.json"
+        path.write_text("{not valid json")
+        with pytest.raises(PackageImportError):
+            import_packages(
+                file_path=str(path), managers=None, dry_run=False, verbose=False
+            )
+
+    def test_import_non_dict_top_level_raises(self, tmp_path) -> None:
+        """import_packages raises PackageImportError when top-level is not a dict."""
+        path = tmp_path / "packages.yaml"
+        path.write_text("- pkg1\n- pkg2\n")
+        with pytest.raises(PackageImportError):
+            import_packages(
+                file_path=str(path), managers=None, dry_run=False, verbose=False
+            )
+
+    def test_import_non_list_manager_value_warns(self, tmp_path, capsys) -> None:
+        """import_packages warns and skips managers whose value is not a list."""
+        data = {"brew": "git"}
+        file_path = self._write_export(tmp_path, data, fmt="json")
+        mock_pm = _make_pm(available=True, packages=[])
+        with patch.object(PackageManagerRegistry, "get_manager", return_value=mock_pm):
+            import_packages(
+                file_path=file_path, managers=None, dry_run=False, verbose=False
+            )
+        captured = capsys.readouterr()
+        assert "expected list" in captured.out
+        mock_pm.install_package.assert_not_called()
+
+    def test_import_unsupported_managers_warn(self, tmp_path, capsys) -> None:
+        """import_packages warns about managers not in EXPORT_SUPPORTED."""
+        data = {"brew": ["git"], "tldr": ["foo"]}
+        file_path = self._write_export(tmp_path, data, fmt="json")
+        mock_pm = _make_pm(available=True, packages=[])
+        with patch.object(PackageManagerRegistry, "get_manager", return_value=mock_pm):
+            import_packages(
+                file_path=file_path, managers=None, dry_run=False, verbose=False
+            )
+        captured = capsys.readouterr()
+        assert "tldr" in captured.out
+        assert "EXPORT_SUPPORTED" in captured.out
+
+    def test_import_install_failure_counted(self, tmp_path, capsys) -> None:
+        """import_packages counts and displays failed installs."""
+        data = {"cargo": ["bat", "fd"]}
+        file_path = self._write_export(tmp_path, data)
+        mock_pm = _make_pm(available=True, packages=[], failed_packages={"fd"})
+        with patch.object(PackageManagerRegistry, "get_manager", return_value=mock_pm):
+            import_packages(
+                file_path=file_path, managers=None, dry_run=False, verbose=False
+            )
+        captured = capsys.readouterr()
+        assert "failed" in captured.out
+        assert "installed" in captured.out
+
+    def test_import_verbose_dry_run_shows_table_entries(self, tmp_path, capsys) -> None:
+        """verbose+dry_run prints skipped and would-install rows in the table."""
+        data = {"brew": ["git", "ripgrep"]}
+        file_path = self._write_export(tmp_path, data)
+        mock_pm = _make_pm(available=True, packages=["git"])
+        with patch.object(PackageManagerRegistry, "get_manager", return_value=mock_pm):
+            import_packages(
+                file_path=file_path,
+                managers=None,
+                dry_run=True,
+                verbose=True,
+            )
+        captured = capsys.readouterr()
+        assert "skipped (already installed)" in captured.out
+        assert "would install" in captured.out
+
+    def test_import_skip_excludes_managers(self, tmp_path) -> None:
+        """import_packages honours the skip list."""
+        data = {"brew": ["git"], "pipx": ["black"]}
+        file_path = self._write_export(tmp_path, data)
+        brew_pm = _make_pm(available=True, packages=[])
+        pipx_pm = _make_pm(available=True, packages=[])
+
+        def _get(name: str, _cfg: dict) -> MagicMock:
+            """Return PM mock by name."""
+            return brew_pm if name == "brew" else pipx_pm
+
+        with patch.object(PackageManagerRegistry, "get_manager", side_effect=_get):
+            import_packages(
+                file_path=file_path,
+                managers=None,
+                dry_run=False,
+                verbose=False,
+                skip=["pipx"],
+            )
+        brew_pm.install_package.assert_called_once_with("git")
+        pipx_pm.install_package.assert_not_called()
 
     def test_import_manager_filter(self, tmp_path) -> None:
         """import_packages only processes managers listed in managers arg."""

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11, <3.14"
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version < '3.12'",
+]
 
 [[package]]
 name = "altgraph"
@@ -18,6 +22,74 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "ansible"
+version = "12.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12'",
+]
+dependencies = [
+    { name = "ansible-core", version = "2.19.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d4/df/60253bfc1f87e3d5b52a06723cc15270428dab113a878cd162ab3923db4e/ansible-12.3.0.tar.gz", hash = "sha256:02721f6fb432ddd47f1044ac49b04b5e9ae08890bd427def8df3db1607aeec51", size = 52065271, upload-time = "2025-12-09T21:04:42.344Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/91/ed9ff629465050d4bdbc9da33d348156736b8778733f97a3627daae4f9ce/ansible-12.3.0-py3-none-any.whl", hash = "sha256:cd156f82fa87f7a899212b0efa9f7ca3a24d609212de9f78428a572eb01e5414", size = 54354494, upload-time = "2025-12-09T21:04:36.923Z" },
+]
+
+[[package]]
+name = "ansible"
+version = "13.7.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+]
+dependencies = [
+    { name = "ansible-core", version = "2.20.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/d0/b083e41b4653ba3ab542c2b58c71afee8a2317a2b23ffe00f574152b53ad/ansible-13.7.0.tar.gz", hash = "sha256:ebca5898346963691915bfea19048f5019b4e46f57e856dc1b790bcde3769224", size = 53216526, upload-time = "2026-05-19T19:52:59.844Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/cc/b0ef8a6a38c5dd4a99d4b6a556ec2fe23adce2c8dbef9a51a898af6698b6/ansible-13.7.0-py3-none-any.whl", hash = "sha256:b3c092ad8cea97c3abd62c3e8ab234ae7f3154b29a40cd826947f1c5d6db92b9", size = 55403780, upload-time = "2026-05-19T19:52:52.248Z" },
+]
+
+[[package]]
+name = "ansible-core"
+version = "2.19.10"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12'",
+]
+dependencies = [
+    { name = "cryptography", marker = "python_full_version < '3.12'" },
+    { name = "jinja2", marker = "python_full_version < '3.12'" },
+    { name = "packaging", marker = "python_full_version < '3.12'" },
+    { name = "pyyaml", marker = "python_full_version < '3.12'" },
+    { name = "resolvelib", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/cb/41f6da397789a82cdfa8e6e7aa16592697af06a4109f77101eb8ee79aae7/ansible_core-2.19.10.tar.gz", hash = "sha256:afe0438d3acb402319baeb12a52465e69642e7497889a3a979cf390c6061a138", size = 3434349, upload-time = "2026-05-18T20:50:16.682Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/1b/d4dbac5ce5f1cbac1a4c8040100b1953f19bad00204643df88ea582838c8/ansible_core-2.19.10-py3-none-any.whl", hash = "sha256:ed6399e42384f55886ba1c9947496beb81f6e6b9f15cd90b3013a78baf6649ab", size = 2416570, upload-time = "2026-05-18T20:50:14.906Z" },
+]
+
+[[package]]
+name = "ansible-core"
+version = "2.20.6"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+]
+dependencies = [
+    { name = "cryptography", marker = "python_full_version >= '3.12'" },
+    { name = "jinja2", marker = "python_full_version >= '3.12'" },
+    { name = "packaging", marker = "python_full_version >= '3.12'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.12'" },
+    { name = "resolvelib", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/48/e33714f82eaae739f805ff3ebc65a19fb7b1ea87bc69231361561762d44f/ansible_core-2.20.6.tar.gz", hash = "sha256:3066c430e8cba46777bf736ebcd085c90b0d7664c3fbd8c5b85227f8579cdcbf", size = 3343241, upload-time = "2026-05-18T20:51:34.619Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/a4/18e26f79d17801a9b23131258479a94f9dad37e40ea3f0cd00b8743800e4/ansible_core-2.20.6-py3-none-any.whl", hash = "sha256:28f8cb1647f3459ccd38d098a06a33eaf49cbfce649e506ae6d5f1c2ac77dc1d", size = 2417498, upload-time = "2026-05-18T20:51:32.62Z" },
 ]
 
 [[package]]
@@ -67,6 +139,54 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/73/f7/f14b46d4bcd21092d7d3ccef689615220d8a08fb25e564b65d20738e672e/certifi-2025.6.15.tar.gz", hash = "sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b", size = 158753, upload-time = "2025-06-15T02:45:51.329Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/ae/320161bd181fc06471eed047ecce67b693fd7515b16d495d8932db763426/certifi-2025.6.15-py3-none-any.whl", hash = "sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057", size = 157650, upload-time = "2025-06-15T02:45:49.977Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
 ]
 
 [[package]]
@@ -157,6 +277,51 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "48.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+    { url = "https://files.pythonhosted.org/packages/be/d2/024b5e06be9d44cb021fb0e1a03d34d63989cf56a0fe62f3dfbab695b9b4/cryptography-48.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:84cf79f0dc8b36ac5da873481716e87aef31fcfa0444f9e1d8b4b2cece142855", size = 3950391, upload-time = "2026-05-04T22:59:17.415Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/17/3861e17c56fa0fd37491a14a8673fdb77c57fc5693cafe745ea8b06dba75/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:fdfef35d751d510fcef5252703621574364fec16418c4a1e5e1055248401054b", size = 4637126, upload-time = "2026-05-04T22:59:20.197Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/0a/7e226dbff530f21480727eb764973a7bff2b912f8e15cd4f129e71b56d1d/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:0890f502ddf7d9c6426129c3f49f5c0a39278ed7cd6322c8755ffca6ee675a13", size = 4667270, upload-time = "2026-05-04T22:59:22.647Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/f2/5a72274ca9f1b2a8b44a662ee0bf1b435909deb473d6f97bcd035bcdbc71/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:ecde28a596bead48b0cfd2a1b4416c3d43074c2d785e3a398d7ec1fc4d0f7fbb", size = 4636797, upload-time = "2026-05-04T22:59:24.912Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e1/48cedb2fe63626e91ded1edad159e2a4fb8b6906c4425eb7749673077ce7/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:4defde8685ae324a9eb9d818717e93b4638ef67070ac9bc15b8ca85f63048355", size = 4666800, upload-time = "2026-05-04T22:59:27.474Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ca/7e8365deec19afb2b2c7be7c1c0aa8f99633b54e90c570999acda93260fc/cryptography-48.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:db63bf618e5dea46c07de12e900fe1cdd2541e6dc9dbae772a70b7d4d4765f6a", size = 3739536, upload-time = "2026-05-04T22:59:29.61Z" },
 ]
 
 [[package]]
@@ -380,7 +545,7 @@ wheels = [
 
 [[package]]
 name = "one-updater"
-version = "0.8.2"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "python-semantic-release" },
@@ -390,9 +555,12 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "ansible", version = "12.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "ansible", version = "13.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "autopep8" },
     { name = "black" },
     { name = "isort" },
+    { name = "passlib" },
     { name = "pre-commit" },
     { name = "pyinstaller" },
     { name = "pytest" },
@@ -401,9 +569,11 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "ansible", marker = "extra == 'dev'" },
     { name = "autopep8", marker = "extra == 'dev'" },
     { name = "black", marker = "extra == 'dev'" },
     { name = "isort", marker = "extra == 'dev'" },
+    { name = "passlib", marker = "extra == 'dev'" },
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "pyinstaller", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
@@ -421,6 +591,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "passlib"
+version = "1.7.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/06/9da9ee59a67fae7761aab3ccc84fa4f3f33f125b370f1ccdb915bf967c11/passlib-1.7.4.tar.gz", hash = "sha256:defd50f72b65c5402ab2c573830a6978e5f202ad0d984793c8dde2c4152ebe04", size = 689844, upload-time = "2020-10-08T19:00:52.121Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/a4/ab6b7589382ca3df236e03faa71deac88cae040af60c071a78d254a62172/passlib-1.7.4-py2.py3-none-any.whl", hash = "sha256:aa6bca462b8d8bda89c70b382f0c298a20b5560af6cbfa2dce410c0a2fb669f1", size = 525554, upload-time = "2020-10-08T19:00:49.856Z" },
 ]
 
 [[package]]
@@ -482,6 +661,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -736,6 +924,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
+]
+
+[[package]]
+name = "resolvelib"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/14/4669927e06631070edb968c78fdb6ce8992e27c9ab2cde4b3993e22ac7af/resolvelib-1.2.1.tar.gz", hash = "sha256:7d08a2022f6e16ce405d60b68c390f054efcfd0477d4b9bd019cc941c28fad1c", size = 24575, upload-time = "2025-10-11T01:07:44.582Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/23/c941a0d0353681ca138489983c4309e0f5095dfd902e1357004f2357ddf2/resolvelib-1.2.1-py3-none-any.whl", hash = "sha256:fb06b66c8da04172d9e72a21d7d06186d8919e32ae5ab5cdf5b9d920be805ac2", size = 18737, upload-time = "2025-10-11T01:07:43.081Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- **feat: add export/import commands and package management methods**
- **chore: update pre-commit hook versions**

## Summary by Sourcery

Add CLI support for exporting and importing installed packages across supported managers, along with foundational package listing and installation capabilities to enable this functionality.

New Features:
- Introduce export CLI command to dump installed packages per manager to YAML or JSON files or stdout.
- Introduce import CLI command to read exported package manifests and install missing packages, with support for dry-run, manager selection, and skipping.
- Add export/import support for multiple package managers by implementing standardized list, install, and installed-check methods and registering them for export.

Enhancements:
- Extend the base package manager abstraction with default list, install, and installed-check hooks and improve command error handling for missing binaries.
- Avoid loading the configuration file for export/import commands that do not require it.

Build:
- Update pre-commit hook versions and development dependencies, including formatter, linter, and tooling hooks.

Tests:
- Add unit and integration tests covering export/import behaviour and the new methods for Homebrew, Cargo, and Pipx managers.