### PR TITLE
feat: add unmanaged binary detection to export command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
 
 -   repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.11.16
+    rev: 0.11.19
     hooks:
     -   id: uv-lock
     -   id: uv-export
@@ -54,7 +54,7 @@ repos:
     -   id: ripsecrets
 
 -   repo: https://github.com/trufflesecurity/trufflehog
-    rev: v3.95.3
+    rev: v3.95.5
     hooks:
     -   id: trufflehog
         name: TruffleHog

--- a/one_updater/cli.py
+++ b/one_updater/cli.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import contextlib
 import json
 import logging
 import os
@@ -220,6 +221,34 @@ def show_version():
         console.print("[red]Error: Could not determine version[/red]")
 
 
+def scan_unmanaged_binaries(
+    managed_names: set[str],
+    scan_dirs: Optional[list[str]] = None,
+) -> list[str]:
+    """Scan directories for executables not managed by any known package manager.
+
+    Returns a sorted list of binary names found in *scan_dirs* that are
+    executable files (or symlinks to them) and whose names are not present
+    in *managed_names*.
+    """
+    if scan_dirs is None:
+        scan_dirs = ["/usr/local/bin", os.path.expanduser("~/.local/bin")]
+
+    found: set[str] = set()
+    for directory in scan_dirs:
+        if not os.path.isdir(directory):
+            continue
+        with contextlib.suppress(OSError):
+            for entry in os.scandir(directory):
+                if (
+                    not entry.is_dir(follow_symlinks=True)
+                    and os.access(entry.path, os.X_OK)
+                    and entry.name not in managed_names
+                ):
+                    found.add(entry.name)
+    return sorted(found)
+
+
 def export_packages(
     managers: Optional[list[str]],
     output: Optional[str],
@@ -227,6 +256,7 @@ def export_packages(
     verbose: bool,
     skip: Optional[list[str]] = None,
 ) -> None:
+    # sourcery skip: low-code-quality
     """Export installed packages grouped by package manager to YAML or JSON."""
     supported = PackageManagerRegistry.EXPORT_SUPPORTED
     targets = sorted([m for m in managers if m in supported] if managers else supported)
@@ -262,20 +292,40 @@ def export_packages(
 
     if not result:
         console.print("[yellow]No packages found to export[/yellow]")
-        return
-
-    if fmt == "json":
-        text = json.dumps(result, indent=2)
     else:
-        text = yaml.dump(result, default_flow_style=False, sort_keys=True)
+        if fmt == "json":
+            text = json.dumps(result, indent=2)
+        else:
+            text = yaml.dump(result, default_flow_style=False, sort_keys=True)
 
-    if output:
-        with open(output, "w", encoding="utf-8") as f:
-            f.write(text)
-        console.print(f"\n[bold green]Exported to {output}[/bold green]")
-    else:
-        console.print("\n")
-        console.print(text)
+        if output:
+            with open(output, "w", encoding="utf-8") as f:
+                f.write(text)
+            console.print(f"\n[bold green]Exported to {output}[/bold green]")
+        else:
+            console.print("\n")
+            console.print(text)
+
+    managed_names: set[str] = set()
+    for pkgs in result.values():
+        managed_names.update(pkgs)
+    targets_set = set(targets)
+    for pm_name in PackageManagerRegistry.EXPORT_SUPPORTED:
+        if pm_name in targets_set:
+            continue
+        with contextlib.suppress(Exception):
+            extra_pm = PackageManagerRegistry.get_manager(pm_name, {"enabled": True})
+            if extra_pm.is_available():
+                if extra_pkgs := extra_pm.list_packages():
+                    managed_names.update(extra_pkgs)
+    if unmanaged := scan_unmanaged_binaries(managed_names):
+        console.print("\n[bold yellow]Other Tools Not Importable:[/bold yellow]")
+        console.print(
+            "[dim](binaries in /usr/local/bin and ~/.local/bin"
+            " not managed by any known package manager)[/dim]"
+        )
+        for tool in unmanaged:
+            console.print(f"  \u2022 {tool}")
 
 
 def import_packages(
@@ -285,6 +335,7 @@ def import_packages(
     verbose: bool,
     skip: Optional[list[str]] = None,
 ) -> None:
+    # sourcery skip: low-code-quality
     """Read an export file and install all packages not already present."""
     if not os.path.exists(file_path):
         error_console.print(f"[red]Error: File not found: {file_path}[/red]")
@@ -343,8 +394,7 @@ def import_packages(
             console.print(f"[yellow]! {name}: expected list, skipping[/yellow]")
             continue
 
-        invalid = [pkg for pkg in packages if not isinstance(pkg, str)]
-        if invalid:
+        if invalid := [pkg for pkg in packages if not isinstance(pkg, str)]:
             error_console.print(
                 f"[red]Error: package list for '{name}' contains non-string "
                 f"entries: {[type(p).__name__ for p in invalid]}[/red]"

--- a/tests/test_export_import.py
+++ b/tests/test_export_import.py
@@ -6,7 +6,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 
-from one_updater.cli import PackageImportError, export_packages, import_packages
+from one_updater.cli import (
+    PackageImportError,
+    export_packages,
+    import_packages,
+    scan_unmanaged_binaries,
+)
 from one_updater.package_managers.brew import HomebrewManager
 from one_updater.package_managers.cargo import CargoManager
 from one_updater.package_managers.pipx import PipxManager
@@ -277,6 +282,147 @@ class TestExportPackages:
         with open(out_file, encoding="utf-8") as f:
             data = yaml.safe_load(f)
         assert data == {"pipx": ["black", "ruff"]}
+
+
+# ---------------------------------------------------------------------------
+# scan_unmanaged_binaries
+# ---------------------------------------------------------------------------
+
+
+class TestScanUnmanagedBinaries:
+    """Unit tests for the scan_unmanaged_binaries helper."""
+
+    def test_nonexistent_dir_returns_empty(self) -> None:
+        """Returns an empty list when the scan directory does not exist."""
+        result = scan_unmanaged_binaries(
+            set(), scan_dirs=["/nonexistent/__test_path__"]
+        )
+        assert result == []
+
+    def test_executable_file_included(self, tmp_path) -> None:
+        """An executable file not in managed_names appears in the result."""
+        (tmp_path / "mytool").write_text("#!/bin/sh")
+        (tmp_path / "mytool").chmod(0o755)
+        result = scan_unmanaged_binaries(set(), scan_dirs=[str(tmp_path)])
+        assert "mytool" in result
+
+    def test_non_executable_file_excluded(self, tmp_path) -> None:
+        """A non-executable regular file is not included."""
+        (tmp_path / "readme.txt").write_text("docs")
+        (tmp_path / "readme.txt").chmod(0o644)
+        result = scan_unmanaged_binaries(set(), scan_dirs=[str(tmp_path)])
+        assert "readme.txt" not in result
+
+    def test_directory_entries_excluded(self, tmp_path) -> None:
+        """Subdirectories are not included even if they are executable."""
+        subdir = tmp_path / "subdir"
+        subdir.mkdir(mode=0o755)
+        result = scan_unmanaged_binaries(set(), scan_dirs=[str(tmp_path)])
+        assert "subdir" not in result
+
+    def test_managed_name_filtered_out(self, tmp_path) -> None:
+        """Binaries whose names are in managed_names are excluded."""
+        for name in ("gah", "neomd", "git"):
+            exe = tmp_path / name
+            exe.write_text("#!/bin/sh")
+            exe.chmod(0o755)
+        result = scan_unmanaged_binaries({"git"}, scan_dirs=[str(tmp_path)])
+        assert "git" not in result
+        assert "gah" in result
+        assert "neomd" in result
+
+    def test_results_are_sorted(self, tmp_path) -> None:
+        """Results are returned in sorted alphabetical order."""
+        for name in ("zzz", "aaa", "mmm"):
+            exe = tmp_path / name
+            exe.write_text("#!/bin/sh")
+            exe.chmod(0o755)
+        result = scan_unmanaged_binaries(set(), scan_dirs=[str(tmp_path)])
+        assert result == sorted(result)
+
+    def test_multiple_dirs_combined(self, tmp_path) -> None:
+        """Binaries from multiple scan directories are merged and deduplicated."""
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        dir_a.mkdir()
+        dir_b.mkdir()
+        for name, d in (("tool1", dir_a), ("tool2", dir_b), ("tool1", dir_b)):
+            exe = d / name
+            exe.write_text("#!/bin/sh")
+            exe.chmod(0o755)
+        result = scan_unmanaged_binaries(set(), scan_dirs=[str(dir_a), str(dir_b)])
+        assert result == ["tool1", "tool2"]
+
+
+# ---------------------------------------------------------------------------
+# export_packages — unmanaged binary section
+# ---------------------------------------------------------------------------
+
+
+class TestExportPackagesUnmanagedBinaries:
+    """Integration tests for the Other Tools Not Importable console section."""
+
+    def test_unmanaged_tools_printed_to_console(self, capsys) -> None:
+        """export_packages prints the section when unmanaged binaries are found."""
+        mock_pm = _make_pm(available=True, packages=["git"])
+        with (
+            patch.object(PackageManagerRegistry, "get_manager", return_value=mock_pm),
+            patch(
+                "one_updater.cli.scan_unmanaged_binaries", return_value=["gah", "neomd"]
+            ),
+        ):
+            export_packages(managers=["brew"], output=None, fmt="yaml", verbose=False)
+        captured = capsys.readouterr()
+        assert "Other Tools Not Importable" in captured.out
+        assert "gah" in captured.out
+        assert "neomd" in captured.out
+
+    def test_no_section_when_no_unmanaged_tools(self, capsys) -> None:
+        """export_packages omits the section entirely when scan returns empty."""
+        mock_pm = _make_pm(available=True, packages=["git"])
+        with (
+            patch.object(PackageManagerRegistry, "get_manager", return_value=mock_pm),
+            patch("one_updater.cli.scan_unmanaged_binaries", return_value=[]),
+        ):
+            export_packages(managers=["brew"], output=None, fmt="yaml", verbose=False)
+        captured = capsys.readouterr()
+        assert "Other Tools Not Importable" not in captured.out
+
+    def test_managed_names_passed_to_scan(self, capsys) -> None:
+        """Package names from all available PMs are forwarded to
+        scan_unmanaged_binaries."""
+        mock_pm = _make_pm(available=True, packages=["git", "vim"])
+        captured_args: dict = {}
+
+        def _capture_scan(managed_names: set, scan_dirs=None) -> list:
+            """Record the managed_names argument and return an empty list."""
+            captured_args["managed_names"] = set(managed_names)
+            return []
+
+        with (
+            patch.object(PackageManagerRegistry, "get_manager", return_value=mock_pm),
+            patch("one_updater.cli.scan_unmanaged_binaries", side_effect=_capture_scan),
+        ):
+            export_packages(managers=["brew"], output=None, fmt="yaml", verbose=False)
+        assert "git" in captured_args["managed_names"]
+        assert "vim" in captured_args["managed_names"]
+
+    def test_unmanaged_section_shown_even_when_no_packages_exported(
+        self, capsys
+    ) -> None:
+        """The binary scan runs even when result is empty (no packages exported)."""
+        mock_pm = _make_pm(available=False, packages=None)
+        with (
+            patch.object(PackageManagerRegistry, "get_manager", return_value=mock_pm),
+            patch(
+                "one_updater.cli.scan_unmanaged_binaries", return_value=["manualtool"]
+            ),
+        ):
+            export_packages(managers=["brew"], output=None, fmt="yaml", verbose=False)
+        captured = capsys.readouterr()
+        assert "No packages found to export" in captured.out
+        assert "Other Tools Not Importable" in captured.out
+        assert "manualtool" in captured.out
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -545,7 +545,7 @@ wheels = [
 
 [[package]]
 name = "one-updater"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "python-semantic-release" },


### PR DESCRIPTION
Add scan_unmanaged_binaries function to identify executables in /usr/local/bin and ~/.local/bin that are not managed by any known package manager. Display these tools in a new "Other Tools Not Importable" section during export to help users identify manually installed binaries that won't be captured in the export file. Include comprehensive test coverage for the scanning logic and console output.

## Summary by Sourcery

Add detection and reporting of locally installed binaries that are not managed by known package managers when exporting packages.

New Features:
- Introduce a scan_unmanaged_binaries helper that discovers unmanaged executables in standard local bin directories.
- Display an 'Other Tools Not Importable' section in the export output listing unmanaged binaries when present.

Enhancements:
- Ensure export_packages always runs the unmanaged binary scan, even when no packages are exported, and includes package names from additional available managers.
- Refine import_packages validation by using an assignment expression for detecting non-string package entries.

Build:
- Update pre-commit hook versions for uv-pre-commit and trufflehog.

Tests:
- Add unit tests for scan_unmanaged_binaries covering executability, filtering, sorting, deduplication, and directory handling.
- Add integration tests verifying unmanaged tools console output behavior in export_packages under various conditions.