### PR TITLE
feat: add bin package manager support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     -   id: pre-commit-update
 
 -   repo: https://github.com/sourcery-ai/sourcery
-    rev: v1.43.0
+    rev: v1.44.0
     hooks:
     -   id: sourcery
         # * review only changed lines:
@@ -26,7 +26,7 @@ repos:
 
 -   repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.11.19
+    rev: 0.12.5
     hooks:
     -   id: uv-lock
     -   id: uv-export
@@ -54,7 +54,7 @@ repos:
     -   id: ripsecrets
 
 -   repo: https://github.com/trufflesecurity/trufflehog
-    rev: v3.95.5
+    rev: v3.97.0
     hooks:
     -   id: trufflehog
         name: TruffleHog

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A flexible package manager updater that helps you keep all your development tool
 - tldr pages
 - go packages
 - apt
+- bin (https://github.com/marcosnils/bin)
 - More coming soon!
 
 ## Installation

--- a/one_updater/configs/all_config.yaml
+++ b/one_updater/configs/all_config.yaml
@@ -14,6 +14,12 @@ package_managers:
       update: ["sudo", "apt-get", "update"]
       upgrade: ["sudo", "apt-get", "upgrade", "-y"]
 
+  bin:
+    enabled: true
+    commands:
+      update: ["bin", "update"]
+      upgrade: ["bin", "update"]
+
   basher:
     enabled: true
     commands:

--- a/one_updater/package_managers/__init__.py
+++ b/one_updater/package_managers/__init__.py
@@ -1,6 +1,7 @@
 from .apt import AptManager
 from .base import PackageManager
 from .basher import BasherManager
+from .bin import BinManager
 from .brew import HomebrewManager
 from .cargo import CargoManager
 from .gem import GemManager
@@ -20,6 +21,7 @@ __all__ = [
     "PackageManager",
     "AptManager",
     "BasherManager",
+    "BinManager",
     "HomebrewManager",
     "CargoManager",
     "GemManager",

--- a/one_updater/package_managers/bin.py
+++ b/one_updater/package_managers/bin.py
@@ -1,0 +1,24 @@
+"""bin package manager implementation."""
+
+from .base import PackageManager
+
+
+class BinManager(PackageManager):
+    """Manager for binaries installed with bin (https://github.com/marcosnils/bin)."""
+
+    def is_available(self) -> bool:
+        """Check if bin is available."""
+        return self.run_command(["which", "bin"])
+
+    def update(self) -> bool:
+        """Update all binaries managed by bin, including bin itself."""
+        if not self.is_available():
+            return False
+        return self.run_command(self.commands.get("update", ["bin", "update"]))
+
+    def upgrade(self) -> bool:
+        """Upgrade all binaries managed by bin."""
+        if not self.is_available():
+            return False
+        # bin update handles both update and upgrade
+        return self.run_command(self.commands.get("upgrade", ["bin", "update"]))

--- a/one_updater/package_managers/registry.py
+++ b/one_updater/package_managers/registry.py
@@ -3,6 +3,7 @@
 from .apt import AptManager
 from .base import PackageManager
 from .basher import BasherManager
+from .bin import BinManager
 from .brew import HomebrewManager
 from .cargo import CargoManager
 from .dnf import DnfManager
@@ -29,6 +30,7 @@ class PackageManagerRegistry:
     _managers: dict[str, type[PackageManager]] = {
         "apt": AptManager,
         "basher": BasherManager,
+        "bin": BinManager,
         "brew": HomebrewManager,
         "cargo": CargoManager,
         "gem": GemManager,

--- a/uv.lock
+++ b/uv.lock
@@ -32,7 +32,7 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "ansible-core", version = "2.19.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "ansible-core", version = "2.19.10", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d4/df/60253bfc1f87e3d5b52a06723cc15270428dab113a878cd162ab3923db4e/ansible-12.3.0.tar.gz", hash = "sha256:02721f6fb432ddd47f1044ac49b04b5e9ae08890bd427def8df3db1607aeec51", size = 52065271, upload-time = "2025-12-09T21:04:42.344Z" }
 wheels = [
@@ -47,7 +47,7 @@ resolution-markers = [
     "python_full_version >= '3.12'",
 ]
 dependencies = [
-    { name = "ansible-core", version = "2.20.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "ansible-core", version = "2.20.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d8/d0/b083e41b4653ba3ab542c2b58c71afee8a2317a2b23ffe00f574152b53ad/ansible-13.7.0.tar.gz", hash = "sha256:ebca5898346963691915bfea19048f5019b4e46f57e856dc1b790bcde3769224", size = 53216526, upload-time = "2026-05-19T19:52:59.844Z" }
 wheels = [
@@ -62,11 +62,11 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "cryptography", marker = "python_full_version < '3.12'" },
-    { name = "jinja2", marker = "python_full_version < '3.12'" },
-    { name = "packaging", marker = "python_full_version < '3.12'" },
-    { name = "pyyaml", marker = "python_full_version < '3.12'" },
-    { name = "resolvelib", marker = "python_full_version < '3.12'" },
+    { name = "cryptography" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "resolvelib" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8d/cb/41f6da397789a82cdfa8e6e7aa16592697af06a4109f77101eb8ee79aae7/ansible_core-2.19.10.tar.gz", hash = "sha256:afe0438d3acb402319baeb12a52465e69642e7497889a3a979cf390c6061a138", size = 3434349, upload-time = "2026-05-18T20:50:16.682Z" }
 wheels = [
@@ -81,11 +81,11 @@ resolution-markers = [
     "python_full_version >= '3.12'",
 ]
 dependencies = [
-    { name = "cryptography", marker = "python_full_version >= '3.12'" },
-    { name = "jinja2", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.12'" },
-    { name = "resolvelib", marker = "python_full_version >= '3.12'" },
+    { name = "cryptography" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "resolvelib" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/48/e33714f82eaae739f805ff3ebc65a19fb7b1ea87bc69231361561762d44f/ansible_core-2.20.6.tar.gz", hash = "sha256:3066c430e8cba46777bf736ebcd085c90b0d7664c3fbd8c5b85227f8579cdcbf", size = 3343241, upload-time = "2026-05-18T20:51:34.619Z" }
 wheels = [
@@ -545,7 +545,7 @@ wheels = [
 
 [[package]]
 name = "one-updater"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "python-semantic-release" },


### PR DESCRIPTION
Add BinManager class to support binaries installed with marcosnils/bin. Include bin in default configuration with update/upgrade commands. Register bin in package manager registry and update README to list bin as a supported package manager.

## Summary by Sourcery

Add bin package manager support to the updater and register it for use through the default configuration.

New Features:
- Add support for managing binaries installed with marcosnils/bin.
- Enable bin in the default package-manager configuration with update and upgrade commands.

Build:
- Update pre-commit tooling versions.

Documentation:
- List bin among the supported package managers.