### PR TITLE
feat: implement export/import support for bin package manager

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     -   id: pre-commit-update
 
 -   repo: https://github.com/sourcery-ai/sourcery
-    rev: v1.44.0
+    rev: v1.45.0
     hooks:
     -   id: sourcery
         # * review only changed lines:
@@ -19,14 +19,14 @@ repos:
         language_version: python3
 
 -   repo: https://github.com/pycqa/isort
-    rev: 8.0.1
+    rev: 9.0.1
     hooks:
     -   id: isort
         args: ["--profile", "black"]
 
 -   repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.12.5
+    rev: 0.12.10
     hooks:
     -   id: uv-lock
     -   id: uv-export
@@ -54,7 +54,7 @@ repos:
     -   id: ripsecrets
 
 -   repo: https://github.com/trufflesecurity/trufflehog
-    rev: v3.97.0
+    rev: v3.97.4
     hooks:
     -   id: trufflehog
         name: TruffleHog

--- a/one_updater/cli.py
+++ b/one_updater/cli.py
@@ -267,6 +267,7 @@ def export_packages(
             console.print(f"[yellow]! {m} is not export-supported, skipping[/yellow]")
 
     result: dict[str, list[str]] = {}
+    managed_binaries: set[str] = set()
     for name in targets:
         try:
             pm = PackageManagerRegistry.get_manager(name, {"enabled": True})
@@ -278,6 +279,8 @@ def export_packages(
             if verbose:
                 console.print(f"[yellow]! {name} not available, skipping[/yellow]")
             continue
+
+        managed_binaries.update(pm.list_managed_binaries())
 
         packages = pm.list_packages()
         if packages is None:
@@ -306,7 +309,7 @@ def export_packages(
             console.print("\n")
             console.print(text)
 
-    managed_names: set[str] = set()
+    managed_names: set[str] = set(managed_binaries)
     for pkgs in result.values():
         managed_names.update(pkgs)
     targets_set = set(targets)
@@ -318,6 +321,7 @@ def export_packages(
             if extra_pm.is_available():
                 if extra_pkgs := extra_pm.list_packages():
                     managed_names.update(extra_pkgs)
+                managed_names.update(extra_pm.list_managed_binaries())
     if unmanaged := scan_unmanaged_binaries(managed_names):
         console.print("\n[bold yellow]Other Tools Not Importable:[/bold yellow]")
         console.print(

--- a/one_updater/cli.py
+++ b/one_updater/cli.py
@@ -254,11 +254,13 @@ def export_packages(
     output: Optional[str],
     fmt: str,
     verbose: bool,
+    config: dict,
     skip: Optional[list[str]] = None,
 ) -> None:
     # sourcery skip: low-code-quality
     """Export installed packages grouped by package manager to YAML or JSON."""
     supported = PackageManagerRegistry.EXPORT_SUPPORTED
+    pkg_cfg = config.get("package_managers", {})
     targets = sorted([m for m in managers if m in supported] if managers else supported)
     if skip:
         targets = [m for m in targets if m not in skip]
@@ -269,6 +271,10 @@ def export_packages(
     result: dict[str, list[str]] = {}
     managed_binaries: set[str] = set()
     for name in targets:
+        if not pkg_cfg.get(name, {}).get("enabled", True):
+            if verbose:
+                console.print(f"[yellow]! {name} disabled in config, skipping[/yellow]")
+            continue
         try:
             pm = PackageManagerRegistry.get_manager(name, {"enabled": True})
         except ValueError as e:
@@ -316,6 +322,8 @@ def export_packages(
     for pm_name in PackageManagerRegistry.EXPORT_SUPPORTED:
         if pm_name in targets_set:
             continue
+        if not pkg_cfg.get(pm_name, {}).get("enabled", True):
+            continue
         with contextlib.suppress(Exception):
             extra_pm = PackageManagerRegistry.get_manager(pm_name, {"enabled": True})
             if extra_pm.is_available():
@@ -337,10 +345,12 @@ def import_packages(
     managers: Optional[list[str]],
     dry_run: bool,
     verbose: bool,
+    config: dict,
     skip: Optional[list[str]] = None,
 ) -> None:
     # sourcery skip: low-code-quality
     """Read an export file and install all packages not already present."""
+    pkg_cfg = config.get("package_managers", {})
     if not os.path.exists(file_path):
         error_console.print(f"[red]Error: File not found: {file_path}[/red]")
         raise PackageImportError(f"File not found: {file_path}")
@@ -393,6 +403,9 @@ def import_packages(
     summary: dict[str, dict[str, int]] = {}
 
     for name in targets:
+        if not pkg_cfg.get(name, {}).get("enabled", True):
+            console.print(f"[yellow]! {name} disabled in config, skipping[/yellow]")
+            continue
         packages = data[name]
         if not isinstance(packages, list):
             console.print(f"[yellow]! {name}: expected list, skipping[/yellow]")
@@ -670,7 +683,7 @@ https://github.com/timmyb824/one-updater
         logger.debug(f"Command line arguments: {args}")
 
         # Load config file if needed
-        if args.command not in ("init", "export", "import"):
+        if args.command != "init":
             config_path = os.path.abspath(
                 os.path.expanduser(args.config or get_default_config_path())
             )
@@ -702,6 +715,7 @@ https://github.com/timmyb824/one-updater
                 args.output,
                 args.format,
                 args.verbose,
+                config,
                 args.skip,
             )
         elif args.command == "import":
@@ -710,6 +724,7 @@ https://github.com/timmyb824/one-updater
                 args.manager,
                 args.dry_run,
                 args.verbose,
+                config,
                 args.skip,
             )
         else:

--- a/one_updater/package_managers/base.py
+++ b/one_updater/package_managers/base.py
@@ -50,7 +50,7 @@ class PackageManager(ABC):
                     check=True,
                 )
                 if result.stdout:
-                    logging.info(
+                    logging.debug(
                         f"INFO - stdout from {' '.join(command)}:\n{result.stdout}"
                     )
 
@@ -142,3 +142,13 @@ class PackageManager(ABC):
         Returns False if unsupported.
         """
         return False
+
+    def list_managed_binaries(self) -> list[str]:
+        """Return executable names this manager places in bin directories.
+
+        Used by ``scan_unmanaged_binaries`` to filter out binaries that are
+        managed by a package manager but whose package name differs from the
+        executable name (e.g. ``bin`` stores URLs but installs executables).
+        Defaults to an empty list; override when needed.
+        """
+        return []

--- a/one_updater/package_managers/basher.py
+++ b/one_updater/package_managers/basher.py
@@ -3,7 +3,6 @@
 import logging
 import os
 import subprocess
-from typing import Optional
 
 from .base import PackageManager
 
@@ -46,7 +45,7 @@ class BasherManager(PackageManager):
             success = False
         return success
 
-    def list_packages(self) -> Optional[list[str]]:
+    def list_packages(self) -> list[str] | None:
         """Return all basher-installed packages as user/package strings."""
         if not self.is_available():
             return None

--- a/one_updater/package_managers/bin.py
+++ b/one_updater/package_managers/bin.py
@@ -1,6 +1,11 @@
 """bin package manager implementation."""
 
+import os
+
 from .base import PackageManager
+
+# Minimum number of columns expected in ``bin ls`` output (Path, Version, URL)
+_MIN_LS_COLUMNS = 3
 
 
 class BinManager(PackageManager):
@@ -22,3 +27,63 @@ class BinManager(PackageManager):
             return False
         # bin update handles both update and upgrade
         return self.run_command(self.commands.get("upgrade", ["bin", "update"]))
+
+    def list_packages(self) -> list[str] | None:
+        """Return all binary install URLs managed by bin.
+
+        The URL column from ``bin ls`` is used because ``bin install <URL>``
+        is the command needed to re-install a binary on another machine.
+        """
+        if not self.is_available():
+            return None
+        ok, stdout, _ = self.run_command_with_output(["bin", "ls"])
+        if not ok or not stdout:
+            return []
+        packages: list[str] = []
+        for line in stdout.strip().splitlines():
+            parts = line.split()
+            # Skip header line and lines with fewer than 3 columns
+            if len(parts) < _MIN_LS_COLUMNS or parts[0] == "Path":
+                continue
+            # URL is the third column (index 2)
+            packages.append(parts[2])
+        return packages
+
+    def install_package(self, name: str) -> bool:
+        """Install a binary with bin by URL.
+
+        Args:
+            name: The install URL (e.g. ``github.com/marcosnils/bin``).
+        """
+        if not self.is_available():
+            return False
+        return self.run_command(["bin", "install", name])
+
+    def is_package_installed(self, name: str) -> bool:
+        """Check whether a binary managed by bin is installed.
+
+        Args:
+            name: The install URL to check for.
+        """
+        packages = self.list_packages()
+        return packages is not None and name in packages
+
+    def list_managed_binaries(self) -> list[str]:
+        """Return executable names that bin installs to bin directories.
+
+        Parses the Path column from ``bin ls`` and returns the basename of
+        each path so ``scan_unmanaged_binaries`` can filter them out.
+        """
+        if not self.is_available():
+            return []
+        ok, stdout, _ = self.run_command_with_output(["bin", "ls"])
+        if not ok or not stdout:
+            return []
+        binaries: list[str] = []
+        for line in stdout.strip().splitlines():
+            parts = line.split()
+            if len(parts) < _MIN_LS_COLUMNS or parts[0] == "Path":
+                continue
+            # Path is the first column; extract the executable name
+            binaries.append(os.path.basename(parts[0]))
+        return binaries

--- a/one_updater/package_managers/bin.py
+++ b/one_updater/package_managers/bin.py
@@ -1,11 +1,9 @@
 """bin package manager implementation."""
 
+import operator
 import os
 
 from .base import PackageManager
-
-# Minimum number of columns expected in ``bin ls`` output (Path, Version, URL)
-_MIN_LS_COLUMNS = 3
 
 
 class BinManager(PackageManager):
@@ -28,6 +26,36 @@ class BinManager(PackageManager):
         # bin update handles both update and upgrade
         return self.run_command(self.commands.get("upgrade", ["bin", "update"]))
 
+    @staticmethod
+    def _parse_bin_ls(stdout: str) -> list[dict[str, str]]:
+        """Parse fixed-width ``bin ls`` table output into row dicts.
+
+        Uses the header line to determine column start positions so that
+        paths containing spaces are handled correctly.
+        """
+        lines = stdout.strip().splitlines()
+        if not lines:
+            return []
+        header = lines[0]
+        # Find start position of each known column header
+        columns: list[tuple[str, int]] = []
+        for name in ("Path", "Version", "URL", "Status"):
+            pos = header.find(name)
+            if pos == -1:
+                return []
+            columns.append((name, pos))
+        columns.sort(key=operator.itemgetter(1))
+        rows: list[dict[str, str]] = []
+        for line in lines[1:]:
+            if not line.strip():
+                continue
+            row: dict[str, str] = {}
+            for i, (name, pos) in enumerate(columns):
+                end = columns[i + 1][1] if i + 1 < len(columns) else len(line)
+                row[name] = line[pos:end].strip()
+            rows.append(row)
+        return rows
+
     def list_packages(self) -> list[str] | None:
         """Return all binary install URLs managed by bin.
 
@@ -39,15 +67,7 @@ class BinManager(PackageManager):
         ok, stdout, _ = self.run_command_with_output(["bin", "ls"])
         if not ok or not stdout:
             return []
-        packages: list[str] = []
-        for line in stdout.strip().splitlines():
-            parts = line.split()
-            # Skip header line and lines with fewer than 3 columns
-            if len(parts) < _MIN_LS_COLUMNS or parts[0] == "Path":
-                continue
-            # URL is the third column (index 2)
-            packages.append(parts[2])
-        return packages
+        return [row["URL"] for row in self._parse_bin_ls(stdout) if row.get("URL")]
 
     def install_package(self, name: str) -> bool:
         """Install a binary with bin by URL.
@@ -79,11 +99,8 @@ class BinManager(PackageManager):
         ok, stdout, _ = self.run_command_with_output(["bin", "ls"])
         if not ok or not stdout:
             return []
-        binaries: list[str] = []
-        for line in stdout.strip().splitlines():
-            parts = line.split()
-            if len(parts) < _MIN_LS_COLUMNS or parts[0] == "Path":
-                continue
-            # Path is the first column; extract the executable name
-            binaries.append(os.path.basename(parts[0]))
-        return binaries
+        return [
+            os.path.basename(row["Path"])
+            for row in self._parse_bin_ls(stdout)
+            if row.get("Path")
+        ]

--- a/one_updater/package_managers/brew.py
+++ b/one_updater/package_managers/brew.py
@@ -50,7 +50,7 @@ class HomebrewManager(PackageManager):
 
         return success
 
-    def list_packages(self) -> Optional[list[str]]:
+    def list_packages(self) -> list[str] | None:
         """Return all installed Homebrew formulae and casks."""
         if not self.is_available():
             return None

--- a/one_updater/package_managers/registry.py
+++ b/one_updater/package_managers/registry.py
@@ -55,6 +55,7 @@ class PackageManagerRegistry:
         {
             "apt",
             "basher",
+            "bin",
             "brew",
             "cargo",
             "dnf",

--- a/tests/test_export_import.py
+++ b/tests/test_export_import.py
@@ -218,6 +218,25 @@ class TestCargoMethods:
 class TestBinMethods:
     """Unit tests for BinManager export/import methods."""
 
+    # Column widths for simulated bin ls output
+    _PATH_W = 45
+    _VER_W = 10
+    _URL_W = 60
+
+    @classmethod
+    def _bin_ls_output(cls, rows: list[tuple[str, str, str]]) -> str:
+        """Build properly aligned bin ls table output for tests."""
+        header = (
+            f"{'Path':<{cls._PATH_W}}{'Version':<{cls._VER_W}}"
+            f"{'URL':<{cls._URL_W}}Status\n"
+        )
+        lines = [header]
+        lines.extend(
+            f"{path:<{cls._PATH_W}}{version:<{cls._VER_W}}{url:<{cls._URL_W}}OK\n"
+            for path, version, url in rows
+        )
+        return "".join(lines)
+
     def test_list_packages_unavailable(self) -> None:
         """list_packages returns None when bin is not available."""
         mgr = BinManager({})
@@ -227,15 +246,24 @@ class TestBinMethods:
     def test_list_packages_parses_ls_output(self) -> None:
         """list_packages extracts URLs from bin ls table output."""
         mgr = BinManager({})
-        output = (
-            "Path                                          Version  URL"
-            "                                                           Status\n"
-            "/Users/timothybryant/.local/bin/bin           v0.29.1"
-            "  github.com/marcosnils/bin                                     OK\n"
-            "/Users/timothybryant/.local/bin/glab-tui      v0.9.0"
-            "  https://github.com/rcieri/glab-tui                            OK\n"
-            "/Users/timothybryant/.local/bin/sysinformer   v1.3.2"
-            "  https://github.com/timmyb824/sysinformer/releases/tag/v1.3.2  OK\n"
+        output = self._bin_ls_output(
+            [
+                (
+                    "/Users/timothybryant/.local/bin/bin",
+                    "v0.29.1",
+                    "github.com/marcosnils/bin",
+                ),
+                (
+                    "/Users/timothybryant/.local/bin/glab-tui",
+                    "v0.9.0",
+                    "https://github.com/rcieri/glab-tui",
+                ),
+                (
+                    "/Users/timothybryant/.local/bin/sysinformer",
+                    "v1.3.2",
+                    "https://github.com/timmyb824/sysinformer/releases/tag/v1.3.2",
+                ),
+            ]
         )
         with (
             patch.object(mgr, "is_available", return_value=True),
@@ -316,15 +344,24 @@ class TestBinMethods:
     def test_list_managed_binaries_parses_paths(self) -> None:
         """list_managed_binaries extracts executable names from bin ls paths."""
         mgr = BinManager({})
-        output = (
-            "Path                                          Version  URL"
-            "                                                           Status\n"
-            "/Users/timothybryant/.local/bin/bin           v0.29.1"
-            "  github.com/marcosnils/bin                                     OK\n"
-            "/Users/timothybryant/.local/bin/glab-tui      v0.9.0"
-            "  https://github.com/rcieri/glab-tui                            OK\n"
-            "/Users/timothybryant/.local/bin/nerdlog       v1.10.0"
-            "  github.com/dimonomid/nerdlog                                  OK\n"
+        output = self._bin_ls_output(
+            [
+                (
+                    "/Users/timothybryant/.local/bin/bin",
+                    "v0.29.1",
+                    "github.com/marcosnils/bin",
+                ),
+                (
+                    "/Users/timothybryant/.local/bin/glab-tui",
+                    "v0.9.0",
+                    "https://github.com/rcieri/glab-tui",
+                ),
+                (
+                    "/Users/timothybryant/.local/bin/nerdlog",
+                    "v1.10.0",
+                    "github.com/dimonomid/nerdlog",
+                ),
+            ]
         )
         with (
             patch.object(mgr, "is_available", return_value=True),
@@ -343,6 +380,52 @@ class TestBinMethods:
         with patch.object(mgr, "is_available", return_value=False):
             assert mgr.list_managed_binaries() == []
 
+    def test_list_packages_with_spaces_in_path(self) -> None:
+        """list_packages correctly parses URLs when path contains spaces."""
+        mgr = BinManager({})
+        output = self._bin_ls_output(
+            [
+                (
+                    "/Users/timothybryant/.local/bin/my tool",
+                    "v1.0.0",
+                    "github.com/example/my-tool",
+                ),
+            ]
+        )
+        with (
+            patch.object(mgr, "is_available", return_value=True),
+            patch.object(
+                mgr,
+                "run_command_with_output",
+                return_value=(True, output, ""),
+            ),
+        ):
+            result = mgr.list_packages()
+        assert result == ["github.com/example/my-tool"]
+
+    def test_list_managed_binaries_with_spaces_in_path(self) -> None:
+        """list_managed_binaries extracts correct name when path has spaces."""
+        mgr = BinManager({})
+        output = self._bin_ls_output(
+            [
+                (
+                    "/Users/timothybryant/.local/bin/my tool",
+                    "v1.0.0",
+                    "github.com/example/my-tool",
+                ),
+            ]
+        )
+        with (
+            patch.object(mgr, "is_available", return_value=True),
+            patch.object(
+                mgr,
+                "run_command_with_output",
+                return_value=(True, output, ""),
+            ),
+        ):
+            result = mgr.list_managed_binaries()
+        assert result == ["my tool"]
+
 
 # ---------------------------------------------------------------------------
 # export_packages CLI function
@@ -357,7 +440,13 @@ class TestExportPackages:
         mock_pm = _make_pm(available=True, packages=["git", "vim"])
 
         with patch.object(PackageManagerRegistry, "get_manager", return_value=mock_pm):
-            export_packages(managers=["brew"], output=None, fmt="yaml", verbose=False)
+            export_packages(
+                managers=["brew"],
+                output=None,
+                fmt="yaml",
+                verbose=False,
+                config={"package_managers": {}},
+            )
 
         captured = capsys.readouterr()
         assert "git" in captured.out
@@ -374,6 +463,7 @@ class TestExportPackages:
                 output=out_file,
                 fmt="json",
                 verbose=False,
+                config={"package_managers": {}},
             )
 
         with open(out_file, encoding="utf-8") as f:
@@ -385,16 +475,42 @@ class TestExportPackages:
         mock_pm = _make_pm(available=False, packages=None)
 
         with patch.object(PackageManagerRegistry, "get_manager", return_value=mock_pm):
-            export_packages(managers=["brew"], output=None, fmt="yaml", verbose=False)
+            export_packages(
+                managers=["brew"],
+                output=None,
+                fmt="yaml",
+                verbose=False,
+                config={"package_managers": {}},
+            )
 
         captured = capsys.readouterr()
         assert "No packages found" in captured.out
 
     def test_export_skips_unsupported_manager_with_warning(self, capsys) -> None:
         """export_packages warns and skips managers not in EXPORT_SUPPORTED."""
-        export_packages(managers=["tldr"], output=None, fmt="yaml", verbose=False)
+        export_packages(
+            managers=["tldr"],
+            output=None,
+            fmt="yaml",
+            verbose=False,
+            config={"package_managers": {}},
+        )
         captured = capsys.readouterr()
         assert "not export-supported" in captured.out
+
+    def test_export_skips_disabled_in_config(self, capsys) -> None:
+        """export_packages skips managers with enabled: false in config."""
+        mock_pm = _make_pm(available=True, packages=["git"])
+        cfg = {"package_managers": {"brew": {"enabled": False}}}
+        with patch.object(PackageManagerRegistry, "get_manager", return_value=mock_pm):
+            export_packages(
+                managers=["brew"], output=None, fmt="yaml", verbose=False, config=cfg
+            )
+        captured = capsys.readouterr()
+        assert "No packages found" in captured.out
+        # brew itself should have been skipped before list_packages was called
+        # on it, but the extra loop may still call list_packages on the mock
+        # for other managers, so we only check the output here.
 
     def test_export_to_file_yaml(self, tmp_path) -> None:
         """export_packages writes valid YAML when fmt='yaml' and output given."""
@@ -407,6 +523,7 @@ class TestExportPackages:
                 output=out_file,
                 fmt="yaml",
                 verbose=False,
+                config={"package_managers": {}},
             )
 
         with open(out_file, encoding="utf-8") as f:
@@ -501,7 +618,13 @@ class TestExportPackagesUnmanagedBinaries:
                 "one_updater.cli.scan_unmanaged_binaries", return_value=["gah", "neomd"]
             ),
         ):
-            export_packages(managers=["brew"], output=None, fmt="yaml", verbose=False)
+            export_packages(
+                managers=["brew"],
+                output=None,
+                fmt="yaml",
+                verbose=False,
+                config={"package_managers": {}},
+            )
         captured = capsys.readouterr()
         assert "Other Tools Not Importable" in captured.out
         assert "gah" in captured.out
@@ -514,7 +637,13 @@ class TestExportPackagesUnmanagedBinaries:
             patch.object(PackageManagerRegistry, "get_manager", return_value=mock_pm),
             patch("one_updater.cli.scan_unmanaged_binaries", return_value=[]),
         ):
-            export_packages(managers=["brew"], output=None, fmt="yaml", verbose=False)
+            export_packages(
+                managers=["brew"],
+                output=None,
+                fmt="yaml",
+                verbose=False,
+                config={"package_managers": {}},
+            )
         captured = capsys.readouterr()
         assert "Other Tools Not Importable" not in captured.out
 
@@ -533,7 +662,13 @@ class TestExportPackagesUnmanagedBinaries:
             patch.object(PackageManagerRegistry, "get_manager", return_value=mock_pm),
             patch("one_updater.cli.scan_unmanaged_binaries", side_effect=_capture_scan),
         ):
-            export_packages(managers=["brew"], output=None, fmt="yaml", verbose=False)
+            export_packages(
+                managers=["brew"],
+                output=None,
+                fmt="yaml",
+                verbose=False,
+                config={"package_managers": {}},
+            )
         assert "git" in captured_args["managed_names"]
         assert "vim" in captured_args["managed_names"]
 
@@ -548,7 +683,13 @@ class TestExportPackagesUnmanagedBinaries:
                 "one_updater.cli.scan_unmanaged_binaries", return_value=["manualtool"]
             ),
         ):
-            export_packages(managers=["brew"], output=None, fmt="yaml", verbose=False)
+            export_packages(
+                managers=["brew"],
+                output=None,
+                fmt="yaml",
+                verbose=False,
+                config={"package_managers": {}},
+            )
         captured = capsys.readouterr()
         assert "No packages found to export" in captured.out
         assert "Other Tools Not Importable" in captured.out
@@ -586,6 +727,7 @@ class TestImportPackages:
                 managers=None,
                 dry_run=False,
                 verbose=False,
+                config={"package_managers": {}},
             )
 
         mock_pm.install_package.assert_not_called()
@@ -603,6 +745,7 @@ class TestImportPackages:
                 managers=None,
                 dry_run=False,
                 verbose=False,
+                config={"package_managers": {}},
             )
 
         mock_pm.install_package.assert_called_once_with("ripgrep")
@@ -620,6 +763,7 @@ class TestImportPackages:
                 managers=None,
                 dry_run=True,
                 verbose=False,
+                config={"package_managers": {}},
             )
 
         mock_pm.install_package.assert_not_called()
@@ -637,6 +781,7 @@ class TestImportPackages:
                 managers=None,
                 dry_run=False,
                 verbose=False,
+                config={"package_managers": {}},
             )
 
         mock_pm.install_package.assert_called_once_with("black")
@@ -649,6 +794,7 @@ class TestImportPackages:
                 managers=None,
                 dry_run=False,
                 verbose=False,
+                config={"package_managers": {}},
             )
 
     def test_import_invalid_json_raises(self, tmp_path) -> None:
@@ -657,7 +803,11 @@ class TestImportPackages:
         path.write_text("{not valid json")
         with pytest.raises(PackageImportError):
             import_packages(
-                file_path=str(path), managers=None, dry_run=False, verbose=False
+                file_path=str(path),
+                managers=None,
+                dry_run=False,
+                verbose=False,
+                config={"package_managers": {}},
             )
 
     def test_import_non_dict_top_level_raises(self, tmp_path) -> None:
@@ -666,7 +816,11 @@ class TestImportPackages:
         path.write_text("- pkg1\n- pkg2\n")
         with pytest.raises(PackageImportError):
             import_packages(
-                file_path=str(path), managers=None, dry_run=False, verbose=False
+                file_path=str(path),
+                managers=None,
+                dry_run=False,
+                verbose=False,
+                config={"package_managers": {}},
             )
 
     def test_import_non_list_manager_value_warns(self, tmp_path, capsys) -> None:
@@ -676,7 +830,11 @@ class TestImportPackages:
         mock_pm = _make_pm(available=True, packages=[])
         with patch.object(PackageManagerRegistry, "get_manager", return_value=mock_pm):
             import_packages(
-                file_path=file_path, managers=None, dry_run=False, verbose=False
+                file_path=file_path,
+                managers=None,
+                dry_run=False,
+                verbose=False,
+                config={"package_managers": {}},
             )
         captured = capsys.readouterr()
         assert "expected list" in captured.out
@@ -689,7 +847,11 @@ class TestImportPackages:
         mock_pm = _make_pm(available=True, packages=[])
         with patch.object(PackageManagerRegistry, "get_manager", return_value=mock_pm):
             import_packages(
-                file_path=file_path, managers=None, dry_run=False, verbose=False
+                file_path=file_path,
+                managers=None,
+                dry_run=False,
+                verbose=False,
+                config={"package_managers": {}},
             )
         captured = capsys.readouterr()
         assert "tldr" in captured.out
@@ -702,7 +864,11 @@ class TestImportPackages:
         mock_pm = _make_pm(available=True, packages=[], failed_packages={"fd"})
         with patch.object(PackageManagerRegistry, "get_manager", return_value=mock_pm):
             import_packages(
-                file_path=file_path, managers=None, dry_run=False, verbose=False
+                file_path=file_path,
+                managers=None,
+                dry_run=False,
+                verbose=False,
+                config={"package_managers": {}},
             )
         captured = capsys.readouterr()
         assert "failed" in captured.out
@@ -719,6 +885,7 @@ class TestImportPackages:
                 managers=None,
                 dry_run=True,
                 verbose=True,
+                config={"package_managers": {}},
             )
         captured = capsys.readouterr()
         assert "skipped (already installed)" in captured.out
@@ -742,6 +909,7 @@ class TestImportPackages:
                 dry_run=False,
                 verbose=False,
                 skip=["pipx"],
+                config={"package_managers": {}},
             )
         brew_pm.install_package.assert_called_once_with("git")
         pipx_pm.install_package.assert_not_called()
@@ -766,6 +934,7 @@ class TestImportPackages:
                 managers=["brew"],
                 dry_run=False,
                 verbose=False,
+                config={"package_managers": {}},
             )
 
         brew_pm.install_package.assert_called_once_with("git")
@@ -784,6 +953,27 @@ class TestImportPackages:
                 managers=None,
                 dry_run=False,
                 verbose=False,
+                config={"package_managers": {}},
             )
 
+        mock_pm.install_package.assert_not_called()
+
+    def test_import_skips_disabled_in_config(self, tmp_path, capsys) -> None:
+        """import_packages skips managers with enabled: false in config."""
+        data = {"brew": ["git"]}
+        file_path = self._write_export(tmp_path, data)
+
+        mock_pm = _make_pm(available=True, packages=[])
+        cfg = {"package_managers": {"brew": {"enabled": False}}}
+
+        with patch.object(PackageManagerRegistry, "get_manager", return_value=mock_pm):
+            import_packages(
+                file_path=file_path,
+                managers=None,
+                dry_run=False,
+                verbose=False,
+                config=cfg,
+            )
+        captured = capsys.readouterr()
+        assert "disabled in config" in captured.out
         mock_pm.install_package.assert_not_called()

--- a/tests/test_export_import.py
+++ b/tests/test_export_import.py
@@ -12,6 +12,7 @@ from one_updater.cli import (
     import_packages,
     scan_unmanaged_binaries,
 )
+from one_updater.package_managers.bin import BinManager
 from one_updater.package_managers.brew import HomebrewManager
 from one_updater.package_managers.cargo import CargoManager
 from one_updater.package_managers.pipx import PipxManager
@@ -212,6 +213,135 @@ class TestCargoMethods:
         ):
             assert mgr.install_package("bat") is True
             mock_run.assert_called_once_with(["cargo", "install", "bat"])
+
+
+class TestBinMethods:
+    """Unit tests for BinManager export/import methods."""
+
+    def test_list_packages_unavailable(self) -> None:
+        """list_packages returns None when bin is not available."""
+        mgr = BinManager({})
+        with patch.object(mgr, "is_available", return_value=False):
+            assert mgr.list_packages() is None
+
+    def test_list_packages_parses_ls_output(self) -> None:
+        """list_packages extracts URLs from bin ls table output."""
+        mgr = BinManager({})
+        output = (
+            "Path                                          Version  URL"
+            "                                                           Status\n"
+            "/Users/timothybryant/.local/bin/bin           v0.29.1"
+            "  github.com/marcosnils/bin                                     OK\n"
+            "/Users/timothybryant/.local/bin/glab-tui      v0.9.0"
+            "  https://github.com/rcieri/glab-tui                            OK\n"
+            "/Users/timothybryant/.local/bin/sysinformer   v1.3.2"
+            "  https://github.com/timmyb824/sysinformer/releases/tag/v1.3.2  OK\n"
+        )
+        with (
+            patch.object(mgr, "is_available", return_value=True),
+            patch.object(
+                mgr,
+                "run_command_with_output",
+                return_value=(True, output, ""),
+            ),
+        ):
+            result = mgr.list_packages()
+        assert result == [
+            "github.com/marcosnils/bin",
+            "https://github.com/rcieri/glab-tui",
+            "https://github.com/timmyb824/sysinformer/releases/tag/v1.3.2",
+        ]
+
+    def test_list_packages_command_failure_returns_empty(self) -> None:
+        """list_packages returns [] when run_command_with_output fails."""
+        mgr = BinManager({})
+        with (
+            patch.object(mgr, "is_available", return_value=True),
+            patch.object(mgr, "run_command_with_output", return_value=(False, "", "")),
+        ):
+            assert mgr.list_packages() == []
+
+    def test_list_packages_empty_stdout_returns_empty(self) -> None:
+        """list_packages returns [] when stdout is empty."""
+        mgr = BinManager({})
+        with (
+            patch.object(mgr, "is_available", return_value=True),
+            patch.object(mgr, "run_command_with_output", return_value=(True, "", "")),
+        ):
+            assert mgr.list_packages() == []
+
+    def test_install_package_calls_bin_install(self) -> None:
+        """install_package delegates to bin install <url>."""
+        mgr = BinManager({})
+        with (
+            patch.object(mgr, "is_available", return_value=True),
+            patch.object(mgr, "run_command", return_value=True) as mock_run,
+        ):
+            assert mgr.install_package("github.com/marcosnils/bin") is True
+            mock_run.assert_called_once_with(
+                ["bin", "install", "github.com/marcosnils/bin"]
+            )
+
+    def test_install_package_unavailable_returns_false(self) -> None:
+        """install_package returns False when bin is not available."""
+        mgr = BinManager({})
+        with (
+            patch.object(mgr, "is_available", return_value=False),
+            patch.object(mgr, "run_command") as mock_run,
+        ):
+            result = mgr.install_package("github.com/marcosnils/bin")
+        assert result is False
+        mock_run.assert_not_called()
+
+    def test_is_package_installed_true(self) -> None:
+        """is_package_installed returns True when URL is in list_packages."""
+        mgr = BinManager({})
+        with patch.object(
+            mgr, "list_packages", return_value=["github.com/marcosnils/bin"]
+        ):
+            assert mgr.is_package_installed("github.com/marcosnils/bin") is True
+
+    def test_is_package_installed_false(self) -> None:
+        """is_package_installed returns False when URL is not in list_packages."""
+        mgr = BinManager({})
+        with patch.object(mgr, "list_packages", return_value=[]):
+            assert mgr.is_package_installed("github.com/marcosnils/bin") is False
+
+    def test_is_package_installed_none_returns_false(self) -> None:
+        """is_package_installed returns False when list_packages is None."""
+        mgr = BinManager({})
+        with patch.object(mgr, "list_packages", return_value=None):
+            assert mgr.is_package_installed("github.com/marcosnils/bin") is False
+
+    def test_list_managed_binaries_parses_paths(self) -> None:
+        """list_managed_binaries extracts executable names from bin ls paths."""
+        mgr = BinManager({})
+        output = (
+            "Path                                          Version  URL"
+            "                                                           Status\n"
+            "/Users/timothybryant/.local/bin/bin           v0.29.1"
+            "  github.com/marcosnils/bin                                     OK\n"
+            "/Users/timothybryant/.local/bin/glab-tui      v0.9.0"
+            "  https://github.com/rcieri/glab-tui                            OK\n"
+            "/Users/timothybryant/.local/bin/nerdlog       v1.10.0"
+            "  github.com/dimonomid/nerdlog                                  OK\n"
+        )
+        with (
+            patch.object(mgr, "is_available", return_value=True),
+            patch.object(
+                mgr,
+                "run_command_with_output",
+                return_value=(True, output, ""),
+            ),
+        ):
+            result = mgr.list_managed_binaries()
+        assert result == ["bin", "glab-tui", "nerdlog"]
+
+    def test_list_managed_binaries_unavailable(self) -> None:
+        """list_managed_binaries returns [] when bin is not available."""
+        mgr = BinManager({})
+        with patch.object(mgr, "is_available", return_value=False):
+            assert mgr.list_managed_binaries() == []
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -545,7 +545,7 @@ wheels = [
 
 [[package]]
 name = "one-updater"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "python-semantic-release" },


### PR DESCRIPTION
Add list_packages, install_package, is_package_installed, and list_managed_binaries methods to BinManager. Parse bin ls output to extract install URLs for export and executable names for unmanaged binary filtering. Update export_packages to collect managed binaries from all package managers to improve scan_unmanaged_binaries accuracy. Add bin to EXPORT_SUPPORTED set in registry. Change logging level from info to debug for command stdout

## Summary by Sourcery

Enable reliable bin package export and import while improving managed binary detection across package managers.

New Features:
- Add export and import support for the bin package manager using install URLs.
- Track binaries managed by package managers so unmanaged binary detection excludes them.

Bug Fixes:
- Improve unmanaged binary scan accuracy for managers whose package identifiers differ from executable names.

Enhancements:
- Honor package-manager enabled settings during export and import.
- Reduce command stdout logging from info to debug.

Build:
- Update pre-commit tooling and security scanning dependencies.

Tests:
- Add coverage for bin output parsing, package operations, managed binary detection, and disabled-manager handling.